### PR TITLE
Tweaking warnings

### DIFF
--- a/koopmans/settings/_workflow.py
+++ b/koopmans/settings/_workflow.py
@@ -61,7 +61,7 @@ class WorkflowSettingsDict(SettingsDictWithChecks):
                     bool, None, (True, False)),
             Setting('mp_correction',
                     'if True, apply the Makov-Payne correction for charged periodic systems',
-                    bool, False, (True, False)),
+                    bool, None, (True, False)),
             Setting('mt_correction',
                     'if True, apply the Martyna-Tuckerman correction for charged aperiodic systems',
                     bool, None, (True, False)),

--- a/koopmans/workflows/_dft.py
+++ b/koopmans/workflows/_dft.py
@@ -16,7 +16,13 @@ from ._workflow import Workflow
 T = TypeVar('T', bound='calculators.CalculatorExt')
 
 
-class DFTCPWorkflow(Workflow):
+class DFTWorkflow(Workflow):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.parameters.functional = 'dft'
+
+
+class DFTCPWorkflow(DFTWorkflow):
 
     def _run(self):
 
@@ -48,7 +54,7 @@ class DFTCPWorkflow(Workflow):
         return calc
 
 
-class DFTPWWorkflow(Workflow):
+class DFTPWWorkflow(DFTWorkflow):
 
     def _run(self):
 
@@ -71,7 +77,7 @@ class DFTPWWorkflow(Workflow):
         return
 
 
-class PWBandStructureWorkflow(Workflow):
+class PWBandStructureWorkflow(DFTWorkflow):
 
     def _run(self):
 

--- a/koopmans/workflows/_koopmans_dscf.py
+++ b/koopmans/workflows/_koopmans_dscf.py
@@ -723,6 +723,15 @@ class KoopmansDSCFWorkflow(Workflow):
 
             converged = all([abs(b.error) < 1e-3 for b in self.bands])
 
+        if self.parameters.functional == 'ki' and self.bands.num(filled=False):
+            # For this case the screening parameters are guaranteed to converge instantly
+            if self.parameters.n_max_sc_steps == 1:
+                # Print the "converged" message rather than the "determined but not necessarily converged" message
+                converged = True
+            else:
+                # Do the subsequent loop
+                utils.warn('The screening parameters for a KI calculation with no empty states will converge '
+                           'instantly; to save computational time set n_max_sc_steps == 1')
         if converged:
             self.print('Screening parameters have been converged')
         else:

--- a/koopmans/workflows/_unfold_and_interp.py
+++ b/koopmans/workflows/_unfold_and_interp.py
@@ -166,6 +166,10 @@ class SingleUnfoldAndInterpolateWorkflow(Workflow):
     command
     '''
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.parameters.calculate_alpha = False
+
     def _run(self):
         '''
         '''

--- a/koopmans/workflows/_wannierize.py
+++ b/koopmans/workflows/_wannierize.py
@@ -31,7 +31,8 @@ class WannierizeWorkflow(Workflow):
 
         pw_params = self.master_calc_params['pw']
 
-        if self.parameters.init_orbitals in ['mlwfs', 'projwfs'] and self.parameters.init_empty_orbitals in ['mlwfs', 'projwfs']:
+        if self.parameters.init_orbitals in ['mlwfs', 'projwfs'] \
+                and self.parameters.init_empty_orbitals in ['mlwfs', 'projwfs']:
 
             if self.parameters.spin_polarised:
                 spins = ['up', 'down']
@@ -74,8 +75,8 @@ class WannierizeWorkflow(Workflow):
             pass
 
         else:
-            raise NotImplementedError('WannierizeWorkflow only supports setting init_orbitals and init_empty_orbitals to '
-                                      '"mlwfs"/"projwfs" or "kohn-sham"')
+            raise NotImplementedError('WannierizeWorkflow only supports setting init_orbitals and init_empty_orbitals '
+                                      'to "mlwfs"/"projwfs" or "kohn-sham"')
 
         # Spin-polarisation
         self._force_nspin2 = force_nspin2
@@ -129,7 +130,8 @@ class WannierizeWorkflow(Workflow):
         calc_pw.prefix = 'nscf'
         self.run_calculator(calc_pw)
 
-        if self.parameters.init_orbitals in ['mlwfs', 'projwfs'] and self.parameters.init_orbitals in ['mlwfs', 'projwfs']:
+        if self.parameters.init_orbitals in ['mlwfs', 'projwfs'] \
+                and self.parameters.init_orbitals in ['mlwfs', 'projwfs']:
             # Loop over the various subblocks that we must wannierise separately
             for block in self.projections:
                 if block.filled:

--- a/koopmans/workflows/_wannierize.py
+++ b/koopmans/workflows/_wannierize.py
@@ -29,10 +29,6 @@ class WannierizeWorkflow(Workflow):
     def __init__(self, *args, force_nspin2=False, scf_kgrid=None, **kwargs):
         super().__init__(*args, **kwargs)
 
-        if 'pw' not in self.master_calc_params:
-            raise ValueError(
-                'You need to provide a pw block in your input')
-
         pw_params = self.master_calc_params['pw']
 
         if self.parameters.init_orbitals in ['mlwfs', 'projwfs'] and self.parameters.init_empty_orbitals in ['mlwfs', 'projwfs']:
@@ -99,6 +95,9 @@ class WannierizeWorkflow(Workflow):
             self.parameters.calculate_bands = True
         else:
             self.parameters.calculate_bands = False
+
+        # This workflow only makes sense for DFT, not an ODD
+        self.parameters.functional = 'dft'
 
     def _run(self):
         '''

--- a/koopmans/workflows/_workflow.py
+++ b/koopmans/workflows/_workflow.py
@@ -372,18 +372,19 @@ class Workflow(ABC):
                     utils.warn('Makov-Payne corrections are not being used; do this with '
                                'caution for periodic systems')
 
+                if self.parameters.eps_inf is None:
+                    utils.warn('eps_inf missing in input; it will default to 1.0. Proceed with caution for periodic '
+                               'systems')
+                    self.parameters.eps_inf = 1.0
+
             if self.parameters.mt_correction is None:
                 self.parameters.mt_correction = False
             if self.parameters.mt_correction:
                 raise ValueError('Do not use Martyna-Tuckerman corrections for periodic systems')
 
             # Check the value of eps_inf
-            if self.parameters.eps_inf is None:
-                utils.warn('eps_inf missing in input; it will default to 1.0. Proceed with caution for periodic '
-                           'systems')
-                self.parameters.eps_inf = 1.0
-            elif self.parameters.eps_inf < 1.0:
-                raise ValueError('eps_inf cannot be lower than 1')
+            if self.parameters.eps_inf and self.parameters.eps_inf < 1.0:
+                raise ValueError('eps_inf cannot be lower than 1.0')
 
             # Check symmetry of the system
             dataset = symmetrize.check_symmetry(self.atoms, 1e-6, verbose=True)

--- a/koopmans/workflows/_workflow.py
+++ b/koopmans/workflows/_workflow.py
@@ -26,6 +26,7 @@ from ase import Atoms
 from ase.build.supercells import make_supercell
 from ase.dft.dos import DOS
 from ase.dft.kpoints import BandPath
+from ase.spacegroup import symmetrize
 from ase.calculators.espresso import Espresso_kcp
 from ase.calculators.calculator import CalculationFailed
 from ase.io.espresso import cell_to_ibrav, ibrav_to_cell, kcp_keys, contruct_kcp_namelist as construct_namelist
@@ -346,23 +347,50 @@ class Workflow(ABC):
                 utils.warn('You have requested a ΔSCF calculation with frozen orbitals. This is unusual; proceed '
                            'only if you know what you are doing')
 
-        if self.parameters.periodic:
-            if self.parameters.gb_correction is None:
-                self.parameters.gb_correction = True
+        if self.parameters.functional == 'dft':
+            self.parameters.calculate_alpha = False
 
-            if self.parameters.mp_correction:
-                if self.parameters.eps_inf is None:
-                    raise ValueError('eps_inf missing in input; needed when mp_correction is true')
-                elif self.parameters.eps_inf < 1.0:
-                    raise ValueError('eps_inf cannot be lower than 1')
-            else:
-                utils.warn('Makov-Payne corrections not applied for a periodic calculation; do this with '
-                           'caution')
+        # Checking periodic image correction schemes
+        if not self.parameters.calculate_alpha:
+            # If we are not calculating alpha, we do not consider charged systems and therefore we don't need image
+            # corrections, so we skip the following checks
+            pass
+        elif self.parameters.periodic:
+            if self.parameters.method == 'dfpt':
+                # For DPFT, we use gb_correction
+                if self.parameters.gb_correction is None:
+                    self.parameters.gb_correction = True
+                if not self.parameters.gb_correction:
+                    utils.warn('Gygi-Baldereschi corrections are not being used; do this with '
+                               'caution for periodic systems')
+
+            elif self.parameters.method == 'dscf':
+                # For DSCF, we use mp_correction
+                if self.parameters.mp_correction is None:
+                    self.parameters.mp_correction = True
+                if not self.parameters.mp_correction:
+                    utils.warn('Makov-Payne corrections are not being used; do this with '
+                               'caution for periodic systems')
 
             if self.parameters.mt_correction is None:
                 self.parameters.mt_correction = False
             if self.parameters.mt_correction:
                 raise ValueError('Do not use Martyna-Tuckerman corrections for periodic systems')
+
+            # Check the value of eps_inf
+            if self.parameters.eps_inf is None:
+                utils.warn('eps_inf missing in input; it will default to 1.0. Proceed with caution for periodic '
+                           'systems')
+                self.parameters.eps_inf = 1.0
+            elif self.parameters.eps_inf < 1.0:
+                raise ValueError('eps_inf cannot be lower than 1')
+
+            # Check symmetry of the system
+            dataset = symmetrize.check_symmetry(self.atoms, 1e-6, verbose=True)
+            if dataset['number'] not in range(195, 231):
+                utils.warn('This system is not cubic and will therefore not have a uniform dielectric tensor. However, '
+                           'the image-correction schemes that are currently implemented assume a uniform dielectric. '
+                           'Proceed with caution')
 
         else:
             if self.parameters.gb_correction is None:

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,3 +11,4 @@ filterwarnings=
     ignore:eps_inf missing in input; it will default to 1.0. Proceed with caution for periodic systems:UserWarning
     ignore:Some of the pseudopotentials do not have PP_PSWFC blocks, which means a projected DOS calculation is not possible. Skipping...:UserWarning
     ignore:Neither a pseudopotential library nor a list of pseudopotentials was provided; defaulting to sg15_v1.2:UserWarning
+    ignore:The screening parameters for a KI calculation with no empty states will converge instantly; to save computational time set n_max_sc_steps == 1:UserWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,8 +6,8 @@ markers=
     tutorials: tests that run the tutorial exercises
 filterwarnings=
     ignore:Could not find 2nd order Makov-Payne energy; applying first order only:UserWarning
-    ignore:Makov-Payne corrections not applied for a periodic calculation; do this with caution:UserWarning
     ignore:Martyna-Tuckerman corrections not applied for an aperiodic calculation; do this with caution:UserWarning
-    ignore:You have not specified a value for eps_inf. This will mean that the screening parameters will converge very slowly with respect to the k- and q-point grids:UserWarning
+    ignore:Makov-Payne corrections are not being used; do this with caution for periodic systems:UserWarning
+    ignore:eps_inf missing in input; it will default to 1.0. Proceed with caution for periodic systems:UserWarning
     ignore:Some of the pseudopotentials do not have PP_PSWFC blocks, which means a projected DOS calculation is not possible. Skipping...:UserWarning
     ignore:Neither a pseudopotential library nor a list of pseudopotentials was provided; defaulting to sg15_v1.2:UserWarning

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -6,3 +6,4 @@ pandas>=1.0.0
 pytest>=5.4
 typing>=3.6
 pybtex>=0.24
+spglib>=1.9


### PR DESCRIPTION
This PR changes several warnings that `koopmans` generates

1. checks the symmetry of the system and generates a warning if it is not cubic and we will be applying image correction schemes, because currently we only support image correction schemes that assume cubic symmetry (closes #137)
2. disables an erroneous warning about the Makov-Payne correction not being used for DFPT workflows, which instead use GB corrections (closes #142)
3. tweaks the warnings at the end of the DSCF cycle so that it doesn't say that the screening parameters aren't necessarily converged if we're doing KI with no empty states (closes #34) 