### PR TITLE
Small bug fix in `flat_alpha` conversion

### DIFF
--- a/koopmans/calculators/_koopmans_cp.py
+++ b/koopmans/calculators/_koopmans_cp.py
@@ -503,9 +503,9 @@ def convert_flat_alphas_for_kcp(flat_alphas: List[float],
     if parameters.nspin == 2:
         nbnd = len(flat_alphas) // 2
         alphas = [flat_alphas[:parameters.nelup]
-                  + flat_alphas[parameters.nelec:-(nbnd - parameters.neldw)],
+                  + flat_alphas[parameters.nelec:(nbnd + parameters.neldw)],
                   flat_alphas[parameters.nelup:parameters.nelec]
-                  + flat_alphas[-(nbnd - parameters.neldw):]]
+                  + flat_alphas[(nbnd + parameters.neldw):]]
     else:
         alphas = [flat_alphas]
     return alphas


### PR DESCRIPTION
The expression to pass from the list `flat_alpha` to the list `alphas` is correct except for a particular case, i.e. when there are no empty orbitals. In such case, the following expression at line 508 of `_koopmans_cp.py`

```
flat_alphas[-(nbnd - parameters.neldw):]
```

becomes `flat_alphas[0:]`, which means that the whole list of screening parameters is appended to the spin down sublist of `alphas`.

Converting `-(nbnd - parameters.neldw)` to `(nbnd + parameters.neldw)` solves the issue.