### PR TITLE
Change order of matches('PBE') and matches('PBESOL')

### DIFF
--- a/quantum_espresso/kcp/Modules/functionals.f90
+++ b/quantum_espresso/kcp/Modules/functionals.f90
@@ -274,16 +274,16 @@ CONTAINS
        call set_dft_value (icorr,4)
        call set_dft_value (igcx, 8)
        call set_dft_value (igcc, 4)
-   else if (matches ('PBE', dftout) ) then
-    ! special case : PBE
-       call set_dft_value (icorr,4)
-       call set_dft_value (igcx, 3)
-       call set_dft_value (igcc, 4)
    else if (matches ('PBESOL', dftout) ) then
     ! special case : PBEsol
        call set_dft_value (icorr,4)
        call set_dft_value (igcx,10)
        call set_dft_value (igcc, 8)
+   else if (matches ('PBE', dftout) ) then
+    ! special case : PBE
+       call set_dft_value (icorr,4)
+       call set_dft_value (igcx, 3)
+       call set_dft_value (igcc, 4)
    else if (matches ('WC', dftout) ) then
     ! special case : Wu-Cohen
        call set_dft_value (icorr,4)


### PR DESCRIPTION
The recent implementation of setting the dft-functional:
```
   else if (matches ('PBE', dftout) ) then
    ! special case : PBE
       call set_dft_value (icorr,4)
       call set_dft_value (igcx, 3)
       call set_dft_value (igcc, 4)
   else if (matches ('PBESOL', dftout) ) then
    ! special case : PBEsol
       call set_dft_value (icorr,4)
       call set_dft_value (igcx,10)
       call set_dft_value (igcc, 8)
```
always sets `input_dft=PBESOL` effectively to `PBE`, since `matches` only checks if the input argument 1 is a substring of the input argument 2 (hence returning true for `matches('PBE', 'PBESOL')` and therefore we never enter the second `else-if`-statement). 
Changing the order, starting the comparision with the longer string:
```
  else if (matches ('PBESOL', dftout) ) then
    ! special case : PBEsol
       call set_dft_value (icorr,4)
       call set_dft_value (igcx,10)
       call set_dft_value (igcc, 8)
   else if (matches ('PBE', dftout) ) then
    ! special case : PBE
       call set_dft_value (icorr,4)
       call set_dft_value (igcx, 3)
       call set_dft_value (igcc, 4)
```
 should fix this issue. 