### PR TITLE
Fixed bug for heavy atoms

### DIFF
--- a/koopmans/calculators/_projwfc.py
+++ b/koopmans/calculators/_projwfc.py
@@ -8,7 +8,6 @@ import os
 import copy
 import numpy as np
 import re
-from glob import glob
 from pathlib import Path
 from typing import List, Dict, Optional
 from ase import Atoms
@@ -62,18 +61,7 @@ class ProjwfcCalculator(CalculatorExt, Projwfc, CalculatorABC):
         Generates a list of orbitals (e.g. 1s, 2s, 2p, ...) expected for each element in the system, based on the
         corresponding pseudopotential.
         """
-        expected_orbitals = {}
-        z_core_to_first_orbital = {0: '1s', 2: '2s', 4: '2p', 10: '3s', 12: '3p', 18: '3d', 28: '4s', 30: '4p',
-                                   36: '4d', 46: '5s', 48: '5p', 50: '6s'}
-        for atom in self.atoms:
-            if atom.symbol in expected_orbitals:
-                continue
-            pseudo_file = self.pseudopotentials[atom.symbol]
-            z_core = atom.number - pseudopotentials.valence_from_pseudo(pseudo_file, self.pseudo_dir)
-            first_orbital = z_core_to_first_orbital[z_core]
-            all_orbitals = list(z_core_to_first_orbital.values())
-            expected_orbitals[atom.symbol] = all_orbitals[all_orbitals.index(first_orbital):]
-        return expected_orbitals
+        return pseudopotentials.expected_subshells(self.atoms, self.pseudopotentials, self.pseudo_dir)
 
     def generate_dos(self) -> GridDOSCollection:
         """

--- a/koopmans/pseudopotentials.py
+++ b/koopmans/pseudopotentials.py
@@ -165,7 +165,7 @@ def expected_subshells(atoms: Atoms, pseudopotentials: Dict[str, str],
         if z_core in z_core_to_first_orbital:
             first_orbital = z_core_to_first_orbital[z_core]
         else:
-            raise ValueError(f'Failed to identify the subshells of the valence of {pseudo_filename}')
+            raise ValueError(f'Failed to identify the subshells of the valence of {pseudo_file}')
         all_orbitals = list(z_core_to_first_orbital.values()) + ['5d', '6p', '6d']
         expected_orbitals[atom.symbol] = sorted(all_orbitals[all_orbitals.index(first_orbital):])
     return expected_orbitals

--- a/koopmans/pseudopotentials.py
+++ b/koopmans/pseudopotentials.py
@@ -165,7 +165,7 @@ def expected_subshells(atoms: Atoms, pseudopotentials: Dict[str, str],
         if z_core in z_core_to_first_orbital:
             first_orbital = z_core_to_first_orbital[z_core]
         else:
-            raise ValueError('Failed to identify the subshells of the valence of {pseudo_filename}')
+            raise ValueError(f'Failed to identify the subshells of the valence of {pseudo_filename}')
         all_orbitals = list(z_core_to_first_orbital.values()) + ['5d', '6p', '6d']
         expected_orbitals[atom.symbol] = sorted(all_orbitals[all_orbitals.index(first_orbital):])
     return expected_orbitals

--- a/koopmans/pseudopotentials.py
+++ b/koopmans/pseudopotentials.py
@@ -14,8 +14,8 @@ import json
 from itertools import chain
 from pathlib import Path
 from dataclasses import dataclass
-from typing import Dict, Optional, List
-import xml.etree.ElementTree as ET
+from typing import Dict, Optional, List, Any
+from upf_to_json import upf_to_json
 from ase import Atoms
 
 
@@ -75,7 +75,8 @@ for pseudo_file in chain(pseudos_directory.rglob('*.UPF'), pseudos_directory.rgl
     elif original_library.startswith('pseudo_dojo'):
         citations.append('Hamann2013')
 
-    pseudo_database.append(Pseudopotential(name, element, pseudo_file.parent, functional, library, kind, citations))
+    pseudo_database.append(Pseudopotential(name, element, pseudo_file.parent,
+                           functional, library, kind, citations, **kwargs))
 
 
 def pseudos_library_directory(pseudo_library: str, base_functional: str) -> Path:
@@ -93,16 +94,16 @@ def fetch_pseudo(**kwargs):
         return matches[0]
 
 
-def read_pseudo_file(fd):
+def read_pseudo_file(filename: Path) -> Dict[str, Any]:
     '''
 
-    Reads in settings from a .upf file using XML parser
+    Reads in settings from a .upf file
 
     '''
 
-    upf = ET.parse(fd).getroot()
+    upf = upf_to_json(open(filename, 'r').read(), filename.name)
 
-    return upf
+    return upf['pseudo_potential']
 
 
 def valence_from_pseudo(filename: str, pseudo_dir: Optional[Path] = None) -> int:
@@ -119,7 +120,7 @@ def valence_from_pseudo(filename: str, pseudo_dir: Optional[Path] = None) -> int
     elif isinstance(pseudo_dir, str):
         pseudo_dir = Path(pseudo_dir)
 
-    return int(float(read_pseudo_file(pseudo_dir / filename).find('PP_HEADER').get('z_valence')))
+    return int(read_pseudo_file(pseudo_dir / filename)['header']['z_valence'])
 
 
 def nelec_from_pseudos(atoms: Atoms, pseudopotentials: Dict[str, str],
@@ -137,3 +138,34 @@ def nelec_from_pseudos(atoms: Atoms, pseudopotentials: Dict[str, str],
 
     valences = [valences_dct[l] for l in labels]
     return sum(valences)
+
+
+def expected_subshells(atoms: Atoms, pseudopotentials: Dict[str, str],
+                       pseudo_dir: Optional[Path] = None) -> Dict[str, List[str]]:
+    """
+    Determine which subshells will make up the valences of a set of pseudopotentials.
+
+    Returns
+    -------
+    Dict[str, List[str]]
+        a dict mapping element names to a corresponding list of suborbitals that *might* be in the pseudopotential
+        valence (depending on how many bands are included)
+
+    """
+
+    z_core_to_first_orbital = {0: '1s', 2: '2s', 4: '2p', 10: '3s', 12: '3p', 18: '3d', 28: '4s', 30: '4p',
+                               36: '4d', 46: '4f', 60: '5s', 62: '5p', 68: '6s'}
+
+    expected_orbitals = {}
+    for atom in atoms:
+        if atom.symbol in expected_orbitals:
+            continue
+        pseudo_file = pseudopotentials[atom.symbol]
+        z_core = atom.number - valence_from_pseudo(pseudo_file, pseudo_dir)
+        if z_core in z_core_to_first_orbital:
+            first_orbital = z_core_to_first_orbital[z_core]
+        else:
+            raise ValueError('Failed to identify the subshells of the valence of {pseudo_filename}')
+        all_orbitals = list(z_core_to_first_orbital.values()) + ['5d', '6p', '6d']
+        expected_orbitals[atom.symbol] = sorted(all_orbitals[all_orbitals.index(first_orbital):])
+    return expected_orbitals

--- a/koopmans/workflows/_dft.py
+++ b/koopmans/workflows/_dft.py
@@ -108,7 +108,7 @@ class PWBandStructureWorkflow(DFTWorkflow):
             # Third, a PDOS calculation
             pseudos = [pseudopotentials.read_pseudo_file(calc_scf.parameters.pseudo_dir / p) for p in
                        self.pseudopotentials.values()]
-            if all([int(p.find('PP_HEADER').get('number_of_wfc')) > 0 for p in pseudos]):
+            if all([p['header']['number_of_wfc'] > 0 for p in pseudos]):
                 calc_dos = self.new_calculator('projwfc')
                 calc_dos.pseudo_dir = calc_bands.parameters.pseudo_dir
                 self.run_calculator(calc_dos)

--- a/koopmans/workflows/_wannierize.py
+++ b/koopmans/workflows/_wannierize.py
@@ -196,7 +196,7 @@ class WannierizeWorkflow(Workflow):
             # Calculate a projected DOS
             pseudos = [read_pseudo_file(calc_pw_bands.parameters.pseudo_dir / p) for p in
                        self.pseudopotentials.values()]
-            if all([int(p.find('PP_HEADER').get('number_of_wfc')) > 0 for p in pseudos]):
+            if all([p['header']['number_of_wfc'] > 0 for p in pseudos]):
                 calc_dos = self.new_calculator('projwfc', filpdos=self.name)
                 calc_dos.directory = 'pdos'
                 calc_dos.pseudopotentials = self.pseudopotentials

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,3 +7,4 @@ pytest>=5.4
 typing>=3.6
 pybtex>=0.24
 spglib>=1.9
+upf-to-json>=0.9.5

--- a/tests/test_pseudopotentials.py
+++ b/tests/test_pseudopotentials.py
@@ -1,0 +1,13 @@
+from ase import Atoms
+from koopmans import pseudopotentials
+
+
+def test_expected_subshells():
+    '''
+    Check that the function expected_subshells doesn't encounter KeyErrors for any element
+    '''
+    for pseudo in pseudopotentials.pseudo_database:
+        atoms = Atoms(pseudo.element)
+        psps = {pseudo.element: pseudo.name}
+        subshells = pseudopotentials.expected_subshells(atoms, psps, pseudo.path)
+        assert len(subshells) > 0


### PR DESCRIPTION
Currently for the pDOS calculations we want to identify which subshells each pDOS corresponds to.

Unfortunately, pseudopotential files do not universally contain this information. Instead, we _guess_ what subshells might be in the valence based on their `z_valence` and their total Z.

The old implementation did not support sufficiently large values of Z. This PR makes the guessing of expected subshells more robust. We also switch over to using `upf_to_json` rather than an xml parser because some pseudos aren't xml-compliant.