### PR TITLE
Fixing print garbage

### DIFF
--- a/koopmans/__init__.py
+++ b/koopmans/__init__.py
@@ -1,5 +1,5 @@
 'Python module for running KI and KIPZ calculations with Quantum Espresso'
 from pathlib import Path
 
-__version__ = '0.6.0'
+__version__ = '0.6.1'
 base_directory = Path(__path__[0]).parent

--- a/koopmans/utils/_io.py
+++ b/koopmans/utils/_io.py
@@ -163,9 +163,9 @@ def indented_print(text: str = '', indent: int = 0, sep: str = ' ', end: str = '
     global print_call_end
     for substring in text.split('\n'):
         if print_call_end == '\n':
-            print(' ' * indent + substring, sep, end, file, flush)
+            print(' ' * indent + substring, sep=sep, end=end, file=file, flush=flush)
         else:
-            print(substring, sep, end, file, flush)
+            print(substring, sep=sep, end=end, file=file, flush=flush)
     print_call_end = end
 
 


### PR DESCRIPTION
Fixing bug from previous commit where kwargs to `print` were being printed instead of being treated as kwargs.