### PR TITLE
Changing ASE installation procedure

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
          - name: Install dependencies
            run: |
               python -m pip install --upgrade pip
-              pip install -e ase/ -e .[test]
+              pip install -e .[test]
          - name: Test the source code
            run: |
               pytest --ci tests/ -m 'not (tutorials or espresso)' --cov-config=.coveragerc --cov=./koopmans/ --cov-report=xml

--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -35,7 +35,7 @@ jobs:
          - name: Install dependencies
            run: |
               python -m pip install --upgrade pip
-              pip install -e ase/ -e .[test]
+              pip install -e .[test]
          - name: Test the tutorials
            run: |
               pytest --ci tests/ -m tutorials

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ espresso: configure_4 espresso_4 configure_7 espresso_7 espresso_utils
 
 workflow:
 	python3 -m pip install --upgrade pip
-	python3 -m pip install -e . -e ase/
+	python3 -m pip install -e .
 
 clean: clean_espresso clean_tests
 

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 # coding: utf-8
 # Distributed under the terms of the MIT License.
 
-from glob import glob
 import os
+from glob import glob
 from typing import Dict
 
 from setuptools import find_packages, setup
@@ -41,9 +41,9 @@ setup(name='koopmans',
       author_email='edwardlinscott@gmail.com',
       maintainer='Edward Linscott',
       maintainer_email='edwardlinscott@gmail.com',
-      license='MIT',
-      packages=find_packages(),
-      package_dir={'': '.'},
+      license='GPL',
+      packages=find_packages() + find_packages('ase'),
+      package_dir={'koopmans': 'koopmans', 'ase': 'ase/ase'},
       python_requires='>=3.7',
       install_requires=requirements,
       scripts=[s for s in glob('bin/*') if s[-2:] != '.x'],


### PR DESCRIPTION
Formally, `koopmans` does not depend on `ase`. We relied on the user running `pip install ase/` in addition to `pip install .`

This causes issues for readthedocs.io, which fails to find `ase`.

This PR makes it such that `ase` is also installed when running `pip install .`