### PR TITLE
Fixing ASE autodoc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,7 @@ import sys
 import sphinx_rtd_theme
 
 sys.path.append('..')
+sys.path.append('../ase')
 
 
 # -- Project information -----------------------------------------------------


### PR DESCRIPTION
Minor change to the docs `conf.py` file to allow readthedocs to find `ase` when using `autodoc`.