### PR TITLE
kpoint hotfix

### DIFF
--- a/koopmans/__init__.py
+++ b/koopmans/__init__.py
@@ -1,5 +1,5 @@
 'Python module for running KI and KIPZ calculations with Quantum Espresso'
 from pathlib import Path
 
-__version__ = '0.7.0'
+__version__ = '0.7.1'
 base_directory = Path(__path__[0]).parent

--- a/koopmans/kpoints.py
+++ b/koopmans/kpoints.py
@@ -228,4 +228,5 @@ def dict_to_kpath(dct: Dict[str, Any]) -> BandPath:
     dct = copy.deepcopy(dct)
     density = dct.pop('density', None)
     cell = Cell(dct.pop('cell')['array'])
-    return BandPath(cell=cell, special_points=cell.bandpath(eps=1e-10).special_points, **dct).interpolate(density=density)
+    return BandPath(cell=cell, special_points=cell.bandpath(eps=1e-10).special_points,
+                    **dct).interpolate(density=density)

--- a/koopmans/kpoints.py
+++ b/koopmans/kpoints.py
@@ -228,4 +228,4 @@ def dict_to_kpath(dct: Dict[str, Any]) -> BandPath:
     dct = copy.deepcopy(dct)
     density = dct.pop('density', None)
     cell = Cell(dct.pop('cell')['array'])
-    return BandPath(cell=cell, special_points=cell.bandpath().special_points, **dct).interpolate(density=density)
+    return BandPath(cell=cell, special_points=cell.bandpath(eps=1e-10).special_points, **dct).interpolate(density=density)


### PR DESCRIPTION
The hypothesis test suite revealed a bug in v0.7: `cell.bandpath().special_points` involved re-categorization of the cell because `bandpath()` has a default tolerance of `2e-4`. Decreased this tolerance to `1e-10`. 