### PR TITLE
Bugfix to readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -23,8 +23,3 @@ python:
   install:
     - requirements: docs/requirements.txt
     - requirements: requirements/requirements.txt
-
-# Make sure to checkout the ase submodule (this is a dependency required for the autodocs)
-submodules:
-  include:
-    - ase


### PR DESCRIPTION
Removed an outdated reference to the ASE submodule in `.readthedocs.yml`