### PR TITLE
Bugfix: NaN in the wfc_centers and spreads when compiling with gfortran 2017

### DIFF
--- a/koopmans/__init__.py
+++ b/koopmans/__init__.py
@@ -1,5 +1,5 @@
 'Python module for running KI and KIPZ calculations with Quantum Espresso'
 from pathlib import Path
 
-__version__ = '1.0.0-beta.1'
+__version__ = '1.0.0-beta.2'
 base_directory = Path(__path__[0]).parent

--- a/quantum_espresso/kcp/CPV/nksiclib.f90
+++ b/quantum_espresso/kcp/CPV/nksiclib.f90
@@ -7497,10 +7497,8 @@ SUBROUTINE compute_nksic_centers(nnrx, nx, nudx, nbsp, nspin, iupdwn, &
       !
       ! compute ionic center of mass
       !
-      CALL ions_cofmass(taus, pmass, na, nsp, rs)
+      CALL ions_cofmass(taus, pmass, na, nsp, r0)
       ! and use it as reference position
-      r0=0.d0 ! FIXME: NsC not sre why rhis was commented out. Need to check what we need here (15/09/2022)
-      !                For now this is fine to avoid NaN when compiling with gfortran 2017
       !
       call compute_dipole( nnrx, 1, orb_rhor(1,1), r0, wfc_centers(1:4, mybnd1, myspin1), &
                                                        wfc_spreads(mybnd1, myspin1, 1))

--- a/quantum_espresso/kcp/CPV/nksiclib.f90
+++ b/quantum_espresso/kcp/CPV/nksiclib.f90
@@ -7487,7 +7487,7 @@ SUBROUTINE compute_nksic_centers(nnrx, nx, nudx, nbsp, nspin, iupdwn, &
    !INTERNAL VARIABLES
    !
    INTEGER :: myspin1, myspin2, mybnd1, mybnd2
-   REAL(DP):: r0(3), rs(3)
+   REAL(DP):: r0(3)
    REAL(DP), external :: ddot
 
    !

--- a/quantum_espresso/kcp/CPV/nksiclib.f90
+++ b/quantum_espresso/kcp/CPV/nksiclib.f90
@@ -7499,7 +7499,8 @@ SUBROUTINE compute_nksic_centers(nnrx, nx, nudx, nbsp, nspin, iupdwn, &
       !
       CALL ions_cofmass(taus, pmass, na, nsp, rs)
       ! and use it as reference position
-      !r0=0.d0
+      r0=0.d0 ! FIXME: NsC not sre why rhis was commented out. Need to check what we need here (15/09/2022)
+      !                For now this is fine to avoid NaN when compiling with gfortran 2017
       !
       call compute_dipole( nnrx, 1, orb_rhor(1,1), r0, wfc_centers(1:4, mybnd1, myspin1), &
                                                        wfc_spreads(mybnd1, myspin1, 1))


### PR DESCRIPTION
Fixed setting the reference point for the centers calculation to 0.0 Might be improved.