### PR TITLE
Removing sphinx directives from README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,7 +97,7 @@ Calculations are run with the command
 
    koopmans <seed>.json
 
-where <seed>.json is the ``koopmans`` input file. For more details, refer to the (`online documentation <https://koopmans-docs.readthedocs.io>`_).
+where <seed>.json is the ``koopmans`` input file. For more details, refer to the `online documentation <https://koopmans-docs.readthedocs.io>`_.
 
 Parallelism
 ^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -97,11 +97,7 @@ Calculations are run with the command
 
    koopmans <seed>.json
 
-where <seed>.json is the ``koopmans`` input file. For a description of the contents of this file, refer to the documentation (`available online <https://koopmans-docs.readthedocs.io>`_). The keywords of ``koopmans`` keywords can be readily listed by running
-
-.. code-block:: bash
-   
-   koopmans --help
+where <seed>.json is the ``koopmans`` input file. For more details, refer to the (`online documentation <https://koopmans-docs.readthedocs.io>`_).
 
 Parallelism
 ^^^^^^^^^^^
@@ -116,10 +112,10 @@ In order to run the code in parallel, define the environment variables ``PARA_PR
 Pseudopotentials
 ^^^^^^^^^^^^^^^^
 
-Currently, Koopmans functionals only works with norm-conserving pseudopotentials. We suggest you use optimized norm-conserving Vanderbilt (ONCV) pseudopotentials :cite:`Hamann2013`, such as
+Currently, Koopmans functionals only works with norm-conserving pseudopotentials. We suggest you use optimized norm-conserving Vanderbilt pseudopotentials, such as
 
-- the `SG15 library <http://www.quantum-simulation.org/potentials/sg15_oncv/index.htm>`_ :cite:`Schlipf2015`
-- the `Pseudo Dojo library <http://www.pseudo-dojo.org/index.html>`_ :cite:`vanSetten2018`
+- the `SG15 library <http://www.quantum-simulation.org/potentials/sg15_oncv/index.htm>`_
+- the `Pseudo Dojo library <http://www.pseudo-dojo.org/index.html>`_
 
 For convenience, ``koopmans`` already ships with both of these pseudopotential libraries and you can simply select the one you want to use using the ``pseudo_library`` keyword.
 

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -34,7 +34,10 @@ and fetch their results e.g.
 
   total_energy = final_calc.results['energy']
 
+Parallelism
+^^^^^^^^^^^
+
 .. include:: ../README.rst
-    :start-line: 101
+    :start-line: 103
     :end-line: 129
 

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -35,6 +35,6 @@ and fetch their results e.g.
   total_energy = final_calc.results['energy']
 
 .. include:: ../README.rst
-    :start-line: 106
-    :end-line: 133
+    :start-line: 102
+    :end-line: 129
 

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -35,6 +35,6 @@ and fetch their results e.g.
   total_energy = final_calc.results['energy']
 
 .. include:: ../README.rst
-    :start-line: 102
+    :start-line: 101
     :end-line: 129
 


### PR DESCRIPTION
... because PyPI requires `README.rst` to be pure rst.

Also updated the `koopmans-kcp` module (only superficial changes made to that code; results won't change)