### PR TITLE
Performing DFPT on a coarser grid

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -133,7 +133,7 @@ Written and maintained by Edward Linscott, Riccardo De Gennaro, and Nicola Colon
 
 For help and feedback email edward.linscott@gmail.com
 
-.. |GH Actions| image:: https://img.shields.io/github/workflow/status/epfl-theos/koopmans/Run%20tests/master?label=master&logo=github
+.. |GH Actions| image:: https://img.shields.io/github/actions/workflow/status/epfl-theos/koopmans/tests.yml?master&label=master&logo=github
    :target: https://github.com/epfl-theos/koopmans/actions?query=branch%3Amaster
 .. |Coverage Status| image:: https://img.shields.io/codecov/c/gh/epfl-theos/koopmans/master?logo=codecov
    :target: https://codecov.io/gh/epfl-theos/koopmans

--- a/README_pypi.rst
+++ b/README_pypi.rst
@@ -27,7 +27,7 @@ Written and maintained by Edward Linscott, Riccardo De Gennaro, and Nicola Colon
 
 For help and feedback email edward.linscott@gmail.com
 
-.. |GH Actions| image:: https://img.shields.io/github/workflow/status/epfl-theos/koopmans/Run%20tests/master?label=master&logo=github
+.. |GH Actions| image:: https://img.shields.io/github/actions/workflow/status/epfl-theos/koopmans/tests.yml?master&label=master&logo=github
    :target: https://github.com/epfl-theos/koopmans/actions?query=branch%3Amaster
 .. |Coverage Status| image:: https://img.shields.io/codecov/c/gh/epfl-theos/koopmans/master?logo=codecov
    :target: https://codecov.io/gh/epfl-theos/koopmans

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "koopmans"
-version = "1.0.0-beta.6"
+version = "1.0.0-rc.1"
 description = "Koopmans spectral functional calculations with python and Quantum ESPRESSO"
 readme = "README_pypi.rst"
 requires-python = ">=3.7"

--- a/src/koopmans/bands.py
+++ b/src/koopmans/bands.py
@@ -212,6 +212,7 @@ class Bands(object):
 
         def points_are_close(p0: Band, p1: Band, factor: Union[int, float] = 1) -> bool:
             # Determine if two bands are "close"
+            assert tol is not None
             return abs(getattr(p0, sort_by) - getattr(p1, sort_by)) < tol * factor
 
         group = 0

--- a/src/koopmans/cli/main.py
+++ b/src/koopmans/cli/main.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import sys
 import argparse
 import textwrap
 
@@ -16,12 +17,18 @@ def main():
         epilog='See https://koopmans-functionals.org for more details')
     parser.add_argument('json', metavar='system.json', type=str,
                         help='a single JSON file containing the workflow and code settings')
+    parser.add_argument('-t', '--traceback', action='store_true', help='enable traceback')
 
     # Parse arguments
     args = parser.parse_args()
 
     # Reading in JSON file
     workflow = read(args.json)
+
+    # Set traceback behaviour
+    if not args.traceback:
+        sys.tracebacklimit = 0
+    
 
     # Run workflow
     workflow.run()

--- a/src/koopmans/settings/_workflow.py
+++ b/src/koopmans/settings/_workflow.py
@@ -111,6 +111,9 @@ class WorkflowSettingsDict(SettingsDictWithChecks):
                     'The observable of interest will be converged with respect to this/these '
                     'simulation parameter(s)',
                     (list, str), ['ecutwfc'], None),
+            Setting('dfpt_coarse_grid',
+                    'The coarse k-point grid on which to perform the DFPT calculations',
+                    list, None, None),
             Setting('eps_cavity',
                     'a list of epsilon_infinity values for the cavity in dscf calculations',
                     list, [1, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20], None)]

--- a/src/koopmans/settings/_workflow.py
+++ b/src/koopmans/settings/_workflow.py
@@ -101,6 +101,10 @@ class WorkflowSettingsDict(SettingsDictWithChecks):
                     'together only if their self-Hartree energy is within this '
                     'threshold',
                     float, None, None),
+            Setting('orbital_groups_spread_tol',
+                    'when calculating alpha parameters, the code will group orbitals '
+                    'together only if their spread is within this threshold',
+                    float, None, None),
             Setting('convergence_observable',
                     'System observable of interest which we converge',
                     str, 'total energy', None),

--- a/src/koopmans/workflows/_koopmans_dfpt.py
+++ b/src/koopmans/workflows/_koopmans_dfpt.py
@@ -39,6 +39,9 @@ class KoopmansDFPTWorkflow(Workflow):
                 raise ValueError(
                     'Calculating screening parameters with DFPT for a non-periodic system is only possible '
                     'with Kohn-Sham orbitals as the variational orbitals')
+        if self.parameters.dfpt_coarse_grid is not None and not self.parameters.calculate_alpha:
+            raise ValueError('Using a DFPT coarse grid to calculate the screening parameters is not possible '
+                             'when calculate_alpha = False')
         for params in self.calculator_parameters.values():
             if all(self.atoms.pbc):
                 # Gygi-Baldereschi
@@ -101,6 +104,8 @@ class KoopmansDFPTWorkflow(Workflow):
             for key in ['pw', 'kc_screen']:
                 self.calculator_parameters[key].kpts = [1, 1, 1]
 
+        self._perform_ham_calc: bool = True
+
     def _run(self):
         '''
         This function runs the workflow from start to finish
@@ -115,6 +120,15 @@ class KoopmansDFPTWorkflow(Workflow):
                 output_directory = Path(output_directory)
                 if output_directory.exists():
                     shutil.rmtree(output_directory)
+
+        if self.parameters.dfpt_coarse_grid is not None:
+            self.print('Coarse grid calculations', style='heading')
+            coarse_wf = self.__class__.fromparent(self)
+            coarse_wf.parameters.dfpt_coarse_grid = None
+            coarse_wf.kpoints.grid = self.parameters.dfpt_coarse_grid
+            coarse_wf._perform_ham_calc = False
+            coarse_wf.run()
+            self.print('Regular grid calculations', style='heading')
 
         if all(self.atoms.pbc):
             # Run PW and Wannierization
@@ -156,33 +170,36 @@ class KoopmansDFPTWorkflow(Workflow):
 
         # Calculate screening parameters
         if self.parameters.calculate_alpha:
-            self.print('Calculation of screening parameters', style='heading')
-            all_groups = [g for gspin in self.parameters.orbital_groups for g in gspin]
-            if len(set(all_groups)) == len(all_groups):
-                # If there is no orbital grouping, do all orbitals in one calculation
-                # 1) Create the calculator
-                kc_screen_calc = self.new_calculator('kc_screen')
-
-                # 2) Run the calculator
-                self.run_calculator(kc_screen_calc)
-
-                # 3) Store the computed screening parameters
-                self.bands.alphas = kc_screen_calc.results['alphas']
-            else:
-                # If there is orbital grouping, do the orbitals one-by-one
-                for band in self.bands.to_solve:
-                    # 1) Create the calculator (in a subdirectory)
-                    kc_screen_calc = self.new_calculator('kc_screen', i_orb=band.index)
-                    kc_screen_calc.directory /= f'band_{band.index}'
+            if self.parameters.dfpt_coarse_grid is None:
+                self.print('Calculation of screening parameters', style='heading')
+                all_groups = [g for gspin in self.parameters.orbital_groups for g in gspin]
+                if len(set(all_groups)) == len(all_groups):
+                    # If there is no orbital grouping, do all orbitals in one calculation
+                    # 1) Create the calculator
+                    kc_screen_calc = self.new_calculator('kc_screen')
 
                     # 2) Run the calculator
                     self.run_calculator(kc_screen_calc)
 
-                    # 3) Store the computed screening parameter (accounting for band groupings)
-                    for b in self.bands:
-                        if b.group == band.group:
-                            alpha = kc_screen_calc.results['alphas'][band.spin]
-                            b.alpha = alpha[band.spin]
+                    # 3) Store the computed screening parameters
+                    self.bands.alphas = kc_screen_calc.results['alphas']
+                else:
+                    # If there is orbital grouping, do the orbitals one-by-one
+                    for band in self.bands.to_solve:
+                        # 1) Create the calculator (in a subdirectory)
+                        kc_screen_calc = self.new_calculator('kc_screen', i_orb=band.index)
+                        kc_screen_calc.directory /= f'band_{band.index}'
+
+                        # 2) Run the calculator
+                        self.run_calculator(kc_screen_calc)
+
+                        # 3) Store the computed screening parameter (accounting for band groupings)
+                        for b in self.bands:
+                            if b.group == band.group:
+                                alpha = kc_screen_calc.results['alphas'][band.spin]
+                                b.alpha = alpha[band.spin]
+            else:
+                self.bands.alphas = coarse_wf.bands.alphas
         else:
             # Load the alphas
             if self.parameters.alpha_from_file:
@@ -191,31 +208,33 @@ class KoopmansDFPTWorkflow(Workflow):
                 self.bands.alphas = self.parameters.alpha_guess
 
         # Calculate the Hamiltonian
-        self.print('Construction of the Hamiltonian', style='heading')
-        kc_ham_calc = self.new_calculator('kc_ham', kpts=self.kpoints.path)
+        if self._perform_ham_calc:
+            self.print('Construction of the Hamiltonian', style='heading')
+            kc_ham_calc = self.new_calculator('kc_ham', kpts=self.kpoints.path)
 
-        if self.parameters.calculate_alpha and kc_ham_calc.parameters.lrpa != kc_screen_calc.parameters.lrpa:
-            raise ValueError('Do not set "lrpa" to different values in the "screen" and "ham" blocks')
-        self.run_calculator(kc_ham_calc)
+            if self.parameters.calculate_alpha and self.parameters.dfpt_coarse_grid is None:
+                if kc_ham_calc.parameters.lrpa != kc_screen_calc.parameters.lrpa:
+                    raise ValueError('Do not set "lrpa" to different values in the "screen" and "ham" blocks')
+            self.run_calculator(kc_ham_calc)
 
-        # Postprocessing
-        if all(self.atoms.pbc) and self.projections and self.kpoints.path is not None \
-                and self.calculator_parameters['ui'].do_smooth_interpolation:
-            from koopmans.workflows import UnfoldAndInterpolateWorkflow
-            self.print(f'\nPostprocessing', style='heading')
-            ui_workflow = UnfoldAndInterpolateWorkflow.fromparent(self)
-            ui_workflow.run(subdirectory='postproc')
+            # Postprocessing
+            if all(self.atoms.pbc) and self.projections and self.kpoints.path is not None \
+                    and self.calculator_parameters['ui'].do_smooth_interpolation:
+                from koopmans.workflows import UnfoldAndInterpolateWorkflow
+                self.print(f'\nPostprocessing', style='heading')
+                ui_workflow = UnfoldAndInterpolateWorkflow.fromparent(self)
+                ui_workflow.run(subdirectory='postproc')
 
-        # Plotting
-        self.plot_bandstructure()
+            # Plotting
+            self.plot_bandstructure()
 
     def plot_bandstructure(self):
         if not all(self.atoms.pbc):
             return
 
         # Identify the relevant calculators
-        [wann2kc_calc] = [c for c in self.calculations if isinstance(c, Wann2KCCalculator)]
-        [kc_ham_calc] = [c for c in self.calculations if isinstance(c, KoopmansHamCalculator)]
+        wann2kc_calc = [c for c in self.calculations if isinstance(c, Wann2KCCalculator)][-1]
+        kc_ham_calc = [c for c in self.calculations if isinstance(c, KoopmansHamCalculator)][-1]
 
         # Plot the bandstructure if the band path has been specified
         bs = kc_ham_calc.results['band structure']

--- a/src/koopmans/workflows/_koopmans_dscf.py
+++ b/src/koopmans/workflows/_koopmans_dscf.py
@@ -9,7 +9,7 @@ Split off from workflow.py Oct 2020
 
 import shutil
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 from ase.dft import DOS
@@ -153,9 +153,13 @@ class KoopmansDSCFWorkflow(Workflow):
                     'of bands'
 
         # Initialize the bands object
+        tols: Dict[str, float] = {}
+        for key in ['self_hartree', 'spread']:
+            val = self.parameters.get(f'orbital_groups_{key}_tol', None)
+            if val is not None:
+                tols[key] = val
         self.bands = Bands(n_bands=[len(f) for f in filling], n_spin=2, spin_polarized=self.parameters.spin_polarized,
-                           filling=filling, groups=groups,
-                           self_hartree_tol=self.parameters.orbital_groups_self_hartree_tol)
+                           filling=filling, groups=groups, tolerances=tols)
 
         if self.parameters.alpha_from_file:
             # Reading alpha values from file
@@ -544,8 +548,7 @@ class KoopmansDSCFWorkflow(Workflow):
             for band in self.bands:
                 # For a KI calculation with only filled bands, we don't have any further calculations to
                 # do, so in this case don't print any headings
-                print_headings = self.parameters.functional != 'ki' \
-                    or any([not b.filled for b in self.bands]) or i_sc == 1
+                print_headings = self.parameters.functional != 'ki' or not band.filled or i_sc == 1
 
                 if self.parameters.spin_polarized and band in first_band_of_each_channel:
                     self.print(f'Spin {band.spin + 1}', style='subheading')
@@ -597,8 +600,6 @@ class KoopmansDSCFWorkflow(Workflow):
 
                 # Don't repeat if this particular alpha_i was converged
                 if i_sc > 1 and abs(band.error) < self.parameters.alpha_conv_thr:
-                    self.print(f'Skipping band {band.index} since this alpha is already converged')
-                    # if self.parameters.from_scratch:
                     for b in self.bands:
                         if b == band or (band.group is not None and b.group == band.group):
                             b.alpha = band.alpha
@@ -670,7 +671,7 @@ class KoopmansDSCFWorkflow(Workflow):
                 # Print summary of all predictions
                 mlfit.print_error_of_all_orbitals(indent=self.print_indent + 1)
 
-        if self.parameters.functional == 'ki' and self.bands.num(filled=False):
+        if self.parameters.functional == 'ki' and self.bands.num(filled=False) == 0:
             # For this case the screening parameters are guaranteed to converge instantly
             if self.parameters.n_max_sc_steps == 1:
                 # Print the "converged" message rather than the "determined but not necessarily converged" message


### PR DESCRIPTION
This PR implements the ability to calculate the screening parameters via DFPT on a coarser grid than that which is used to construct the Hamiltonian. This is controlled by the keyword `dfpt_coarse_grid` in the `workflow` block, which is a direct analogue of the `grid` keyword in the `kpoints` block.

It also introduces the ability to group variational orbitals based on their spread (provided that they are Wannier functions). This is required in order to perform orbital grouping for DFPT workflows.

Finally, this PR makes `koopmans` suppress traceback by default. This can be re-enabled by running `koopmans` with the flag `--traceback` or `-t`.