### PR TITLE
Allowing to compute only the DOS during a DFT bands workflow

### DIFF
--- a/src/koopmans/kpoints.py
+++ b/src/koopmans/kpoints.py
@@ -53,7 +53,7 @@ class Kpoints:
         self.gamma_only = gamma_only
 
         if gamma_only:
-            if grid:
+            if grid and not grid == [1, 1, 1]:
                 raise ValueError(f'gamma_only = {gamma_only} and grid != None are incompatible')
             self.grid = None
             self.offset = [0, 0, 0]

--- a/src/koopmans/workflows/_dft.py
+++ b/src/koopmans/workflows/_dft.py
@@ -113,12 +113,16 @@ class DFTBandsWorkflow(DFTWorkflow):
             self.run_calculator(calc_scf)
 
             # Second, a bands calculation
-            calc_bands = self.new_calculator('pw', calculation='bands', kpts=self.kpoints.path)
+            if self.parameters.calculate_bands in (True, None):
+                calc_bands = self.new_calculator('pw', calculation='bands', kpts=self.kpoints.path)
+            else:
+                calc_bands = self.new_calculator('pw', calculation='nscf')
             calc_bands.prefix = 'bands'
             self.run_calculator(calc_bands)
 
             # Prepare the band structure for plotting
-            bs = calc_bands.results['band structure']
+            if self.parameters.calculate_bands in (True, None):
+                bs = calc_bands.results['band structure']
 
             # Third, a PDOS calculation
             pseudos = [pseudopotentials.read_pseudo_file(calc_scf.parameters.pseudo_dir / p) for p in
@@ -130,7 +134,8 @@ class DFTBandsWorkflow(DFTWorkflow):
 
                 # Prepare the DOS for plotting
                 dos = copy.deepcopy(calc_dos.results['dos'])
-                dos._energies -= bs.reference
+                if self.parameters.calculate_bands in (True, None):
+                    dos._energies -= bs.reference
             else:
                 # Skip if the pseudos don't have the requisite PP_PSWFC blocks
                 utils.warn('Some of the pseudopotentials do not have PP_PSWFC blocks, which means a projected DOS '
@@ -138,7 +143,12 @@ class DFTBandsWorkflow(DFTWorkflow):
                 dos = None
 
             # Plot the band structure and DOS
-            self.plot_bandstructure(bs.subtract_reference(), dos)
+            if self.parameters.calculate_bands in (True, None):
+                self.plot_bandstructure(bs.subtract_reference(), dos)
+            elif dos is not None:
+                workflow_name = self.__class__.__name__.lower()
+                filename = f'{self.name}_{workflow_name}_dos'
+                dos.plot(filename=filename)
 
     def new_calculator(self,
                        calc_type: str,

--- a/src/koopmans/workflows/_singlepoint.py
+++ b/src/koopmans/workflows/_singlepoint.py
@@ -16,6 +16,7 @@ import numpy as np
 from koopmans import utils
 
 from ._workflow import Workflow
+from koopmans.calculators import ProjwfcCalculator
 
 load_results_from_output = True
 
@@ -132,8 +133,10 @@ class SinglepointWorkflow(Workflow):
                     if all(self.atoms.pbc) and self.calculator_parameters['ui'].do_smooth_interpolation:
                         if not Path('pkipz/postproc').is_dir():
                             utils.system_call('mkdir pkipz/postproc')
-                        for dir in ['wannier', 'TMP', 'pdos']:
+                        for dir in ['wannier', 'TMP']:
                             utils.system_call(f'rsync -a ki/postproc/{dir} pkipz/postproc/')
+                        if any([isinstance(c, ProjwfcCalculator) for c in self.calculations]):
+                            utils.system_call(f'rsync -a ki/postproc/pdos pkipz/postproc/')
 
                     # KIPZ
                     utils.system_call('rsync -a ki/final/ kipz/init/')
@@ -143,8 +146,10 @@ class SinglepointWorkflow(Workflow):
                         utils.system_call('rsync -a ki/init/wannier kipz/init/')
                     if all(self.atoms.pbc) and self.calculator_parameters['ui'].do_smooth_interpolation:
                         # Copy over the smooth PBE calculation from KI for KIPZ to use
-                        for dir in ['wannier', 'TMP', 'pdos']:
+                        for dir in ['wannier', 'TMP']:
                             utils.system_call(f'rsync -a ki/postproc/{dir} kipz/postproc/')
+                        if any([isinstance(c, ProjwfcCalculator) for c in self.calculations]):
+                            utils.system_call(f'rsync -a ki/postproc/pdos pkipz/postproc/')
 
         else:
             # self.functional != all and self.method != 'dfpt'

--- a/src/koopmans/workflows/_singlepoint.py
+++ b/src/koopmans/workflows/_singlepoint.py
@@ -133,10 +133,9 @@ class SinglepointWorkflow(Workflow):
                     if all(self.atoms.pbc) and self.calculator_parameters['ui'].do_smooth_interpolation:
                         if not Path('pkipz/postproc').is_dir():
                             utils.system_call('mkdir pkipz/postproc')
-                        for dir in ['wannier', 'TMP']:
-                            utils.system_call(f'rsync -a ki/postproc/{dir} pkipz/postproc/')
-                        if any([isinstance(c, ProjwfcCalculator) for c in self.calculations]):
-                            utils.system_call(f'rsync -a ki/postproc/pdos pkipz/postproc/')
+                        for dir in ['wannier', 'TMP', 'pdos']:
+                            if Path(f'ki/postproc/{dir}').exists():
+                                utils.system_call(f'rsync -a ki/postproc/{dir} pkipz/postproc/')
 
                     # KIPZ
                     utils.system_call('rsync -a ki/final/ kipz/init/')
@@ -146,10 +145,9 @@ class SinglepointWorkflow(Workflow):
                         utils.system_call('rsync -a ki/init/wannier kipz/init/')
                     if all(self.atoms.pbc) and self.calculator_parameters['ui'].do_smooth_interpolation:
                         # Copy over the smooth PBE calculation from KI for KIPZ to use
-                        for dir in ['wannier', 'TMP']:
-                            utils.system_call(f'rsync -a ki/postproc/{dir} kipz/postproc/')
-                        if any([isinstance(c, ProjwfcCalculator) for c in self.calculations]):
-                            utils.system_call(f'rsync -a ki/postproc/pdos kipz/postproc/')
+                        for dir in ['wannier', 'TMP', 'pdos']:
+                            if Path(f'ki/postproc/{dir}').exists():
+                                utils.system_call(f'rsync -a ki/postproc/{dir} kipz/postproc/')
 
         else:
             # self.functional != all and self.method != 'dfpt'

--- a/src/koopmans/workflows/_singlepoint.py
+++ b/src/koopmans/workflows/_singlepoint.py
@@ -149,7 +149,7 @@ class SinglepointWorkflow(Workflow):
                         for dir in ['wannier', 'TMP']:
                             utils.system_call(f'rsync -a ki/postproc/{dir} kipz/postproc/')
                         if any([isinstance(c, ProjwfcCalculator) for c in self.calculations]):
-                            utils.system_call(f'rsync -a ki/postproc/pdos pkipz/postproc/')
+                            utils.system_call(f'rsync -a ki/postproc/pdos kipz/postproc/')
 
         else:
             # self.functional != all and self.method != 'dfpt'


### PR DESCRIPTION
The keyword `calculate_bands` was previously ignored during the `DFTBandsWorkflow`. We allow to skip the band structure calculation and to compute only the DOS when `calculate_bands=True`.