### PR TITLE
Easier plotting of real space densities

### DIFF
--- a/src/koopmans/utils/_xml.py
+++ b/src/koopmans/utils/_xml.py
@@ -35,7 +35,7 @@ def read_xml_nr(xml_file: Path, string: str = 'EFFECTIVE-POTENTIAL') -> List[int
     return _get_nr(branch)
 
 
-def read_xml_array(xml_file: Path, norm_const: float, string: str = 'EFFECTIVE-POTENTIAL') -> np.ndarray:
+def read_xml_array(xml_file: Path, norm_const: float, string: str = 'EFFECTIVE-POTENTIAL', in_xsf_format: bool=False) -> np.ndarray:
     """
     Loads an array from an xml file
     """
@@ -60,4 +60,7 @@ def read_xml_array(xml_file: Path, norm_const: float, string: str = 'EFFECTIVE-P
                 array_xml[k, j, i] = rho_tmp[(j % (nr_xml[1]-1))*(nr_xml[0]-1)+(i % (nr_xml[0]-1))]
     array_xml *= norm_const
 
-    return array_xml[:-1, :-1, :-1]
+    if in_xsf_format: # the xsf format requires an array where the last element is equal to the first element in each dimension
+        return array_xml
+    else:
+        return array_xml[:-1, :-1, :-1]

--- a/src/koopmans/utils/_xml.py
+++ b/src/koopmans/utils/_xml.py
@@ -35,9 +35,16 @@ def read_xml_nr(xml_file: Path, string: str = 'EFFECTIVE-POTENTIAL') -> List[int
     return _get_nr(branch)
 
 
-def read_xml_array(xml_file: Path, norm_const: float, string: str = 'EFFECTIVE-POTENTIAL', in_xsf_format: bool=False) -> np.ndarray:
+def read_xml_array(xml_file: Path, norm_const: float, string: str = 'EFFECTIVE-POTENTIAL', retain_final_element: bool=False) -> np.ndarray:
     """
-    Loads an array from an xml file
+    Loads an array from an xml file.
+    
+    :param xml_file: The xml file to read from
+    :param norm_const: The normalization constant to multiply the array with (in our case 1/((Bohr radii)^3)
+    :param string: The name of the field in the xml file that contains the array, in our case either 'EFFECTIVE-POTENTIAL' or 'CHARGE-DENSITY'
+    :param retain_final_element: If True, the array is returned in with periodic boundary conditions, i.e. the last element in each dimension is equal to the first element in each dimension. This is required for the xsf format.
+    
+    :return: The array
     """
 
     # Load the branch of the xml tree
@@ -60,7 +67,7 @@ def read_xml_array(xml_file: Path, norm_const: float, string: str = 'EFFECTIVE-P
                 array_xml[k, j, i] = rho_tmp[(j % (nr_xml[1]-1))*(nr_xml[0]-1)+(i % (nr_xml[0]-1))]
     array_xml *= norm_const
 
-    if in_xsf_format: # the xsf format requires an array where the last element is equal to the first element in each dimension
+    if retain_final_element: # the xsf format requires an array where the last element is equal to the first element in each dimension
         return array_xml
     else:
         return array_xml[:-1, :-1, :-1]

--- a/src/koopmans/utils/_xml.py
+++ b/src/koopmans/utils/_xml.py
@@ -35,14 +35,18 @@ def read_xml_nr(xml_file: Path, string: str = 'EFFECTIVE-POTENTIAL') -> List[int
     return _get_nr(branch)
 
 
-def read_xml_array(xml_file: Path, norm_const: float, string: str = 'EFFECTIVE-POTENTIAL', retain_final_element: bool=False) -> np.ndarray:
+def read_xml_array(
+    xml_file: Path, norm_const: float, string: str = 'EFFECTIVE-POTENTIAL', retain_final_element: bool=False
+    ) -> np.ndarray:
     """
     Loads an array from an xml file.
     
     :param xml_file: The xml file to read from
     :param norm_const: The normalization constant to multiply the array with (in our case 1/((Bohr radii)^3)
-    :param string: The name of the field in the xml file that contains the array, in our case either 'EFFECTIVE-POTENTIAL' or 'CHARGE-DENSITY'
-    :param retain_final_element: If True, the array is returned in with periodic boundary conditions, i.e. the last element in each dimension is equal to the first element in each dimension. This is required for the xsf format.
+    :param string: The name of the field in the xml file that contains the array, in our case either 
+    'EFFECTIVE-POTENTIAL' or 'CHARGE-DENSITY'
+    :param retain_final_element: If True, the array is returned in with periodic boundary conditions, i.e. the last 
+    element in each dimension is equal to the first element in each dimension. This is required for the xsf format.
     
     :return: The array
     """
@@ -67,7 +71,8 @@ def read_xml_array(xml_file: Path, norm_const: float, string: str = 'EFFECTIVE-P
                 array_xml[k, j, i] = rho_tmp[(j % (nr_xml[1]-1))*(nr_xml[0]-1)+(i % (nr_xml[0]-1))]
     array_xml *= norm_const
 
-    if retain_final_element: # the xsf format requires an array where the last element is equal to the first element in each dimension
+    if retain_final_element: 
+        # the xsf format requires an array where the last element is equal to the first element in each dimension
         return array_xml
     else:
         return array_xml[:-1, :-1, :-1]

--- a/src/koopmans/utils/_xsf.py
+++ b/src/koopmans/utils/_xsf.py
@@ -28,7 +28,7 @@ def write_xsf(filename: Path, atoms: Atoms, arrays: List[np.ndarray], nr_xml: Tu
         out.write('CRYSTAL\n\n')
         out.write('PRIMVEC\n\n')
         for vec in cell_parameters:
-            out.write("\t" + " ".join([f"{x:13.10f}" for x in vec]))
+            out.write("\t" + " ".join([f"{x:13.10f}" for x in vec])+ " \n")
         out.write('PRIMCOORD\n')
         out.write(f"\t{len(symbols)}\t1\n")
         for symbol, pos in zip(symbols, positions):


### PR DESCRIPTION
The purpose of this PR is to simplify calling `write_xsf` as a standalone routine (to plot the real space densities, e.g. for debugging). 
For this purpose

1. an additional flag was added to `read_xml_array`, to be able to return the array obtained from the xml file in the correct format that is required for the xsf-format (where the last element is equal to the first element in each dimension)
2. a small bug in `read_xml_array` was fixed (missing `" \n"`)

Now the real space density can be written to a xsf file suitable for plotting (e.g. with xcrysden) in the following way:
```python
# read the xml-file into an array
xml_file = f'{xml_orbital_dir}/orbital.{filled_str}.{band_spin}.{band_index:05d}.xml'
norm_const = 1/(units.Bohr)**3
rho_r_xsf_array = read_xml_array(xml_file, norm_const, write_array_for_xsf=True)


# write the array to xsf file
xsf_file = f'orbital.{filled_str}.{band_spin}.{band_index:05d}.xsf'
nr_xml = read_xml_nr(xml_file)
write_xsf(xsf_file, atoms, [rho_r_xsf_array], nr_xml)
``` 