### PR TITLE
Fix the reading of screening parameters from file in the DFPT workflow

### DIFF
--- a/src/koopmans/calculators/_koopmans_cp.py
+++ b/src/koopmans/calculators/_koopmans_cp.py
@@ -444,7 +444,7 @@ class KoopmansCPCalculator(CalculatorCanEnforceSpinSym, CalculatorExt, Espresso_
 
         flat_alphas = [a for sublist in self.alphas for a in sublist]
         flat_filling = [f for sublist in self.filling for f in sublist]
-        utils.write_alpha_file(self, flat_alphas, flat_filling)
+        utils.write_alpha_files(self, flat_alphas, flat_filling)
 
     def read_alphas(self) -> List[List[float]]:
         """Read in file_alpharef.txt and file_alpharef_empty.txt from this calculation's directory.
@@ -456,7 +456,7 @@ class KoopmansCPCalculator(CalculatorCanEnforceSpinSym, CalculatorExt, Espresso_
             return [[]]
 
         assert self.directory is not None
-        flat_alphas = utils.read_alpha_file(self)
+        flat_alphas = utils.read_alpha_files(self)
 
         assert isinstance(self.parameters, settings.KoopmansCPSettingsDict)
 

--- a/src/koopmans/calculators/_koopmans_ham.py
+++ b/src/koopmans/calculators/_koopmans_ham.py
@@ -39,7 +39,7 @@ class KoopmansHamCalculator(KCWannCalculator, KoopmansHam, ReturnsBandStructure,
         single file for the alphas (rather than splitting between filled/empty)
         """
         fake_filling = [True for _ in self.alphas]
-        utils.write_alpha_file(self, self.alphas, fake_filling)
+        utils.write_alpha_files(self, self.alphas, fake_filling)
 
     def _pre_calculate(self):
         super()._pre_calculate()

--- a/src/koopmans/utils/__init__.py
+++ b/src/koopmans/utils/__init__.py
@@ -11,8 +11,9 @@ from ._io import (construct_atomic_positions_block,
                   parse_wannier_centers_file_contents,
                   parse_wannier_hr_file_contents,
                   parse_wannier_u_file_contents, print_alert, read_alpha_file,
-                  read_atomic_positions, read_cell_parameters,
-                  read_wannier_hr_file, write_alpha_file)
+                  read_alpha_files, read_atomic_positions,
+                  read_cell_parameters, read_wannier_hr_file,
+                  write_alpha_files)
 from ._misc import flatten, update_nested_dict
 from ._os import (HasDirectory, chdir, chdir_logic, copy_file, find_executable,
                   set_env, symlink, symlink_tree, system_call)

--- a/src/koopmans/utils/_io.py
+++ b/src/koopmans/utils/_io.py
@@ -75,7 +75,7 @@ def construct_atomic_positions_block(atoms: Atoms, crystal: bool = True) -> dict
     return dct
 
 
-def write_alpha_file(parent_process: HasDirectory, alphas: List[float], filling: List[bool]):
+def write_alpha_files(parent_process: HasDirectory, alphas: List[float], filling: List[bool]):
     """Write the screening parameters to a file in the directory of `parent_process`."""
     from koopmans.files import File
 
@@ -89,16 +89,27 @@ def write_alpha_file(parent_process: HasDirectory, alphas: List[float], filling:
         dst_file.write_text(content)
 
 
-def read_alpha_file(parent_process: HasDirectory) -> List[float]:
-    """Read the alpha file and return the list of alphas."""
+def read_alpha_file(alpha_file: File) -> List[float]:
+    """Read an alpha file and return the list of alphas."""
+    alphas: List[float] = []
+    if not alpha_file.exists():
+        raise FileNotFoundError(f'{alpha_file} does not exist')
+    flines = alpha_file.read_text().split('\n')
+    n_orbs = int(flines[0])
+    alphas += [float(line.split()[1]) for line in flines[1:n_orbs + 1]]
+    return alphas
+
+
+def read_alpha_files(parent_process: HasDirectory) -> List[float]:
+    """Read all alpha files and return the list of alphas."""
+    from koopmans.files import File
+
     alphas: List[float] = []
     for suffix in ['', '_empty']:
         fname = File(parent_process, f'file_alpharef{suffix}.txt')
         if not fname.exists():
             break
-        flines = fname.read_text().split('\n')
-        n_orbs = int(flines[0])
-        alphas += [float(line.split()[1]) for line in flines[1:n_orbs + 1]]
+        alphas += read_alpha_file(fname)
     return alphas
 
 
@@ -350,7 +361,8 @@ def parse_wannier_centers_file_contents(content: str) -> Tuple[List[List[float]]
         if line.startswith('X    '):
             centers.append([float(x) for x in line.split()[1:]])
         else:
-            symbols.append(line.split()[0])
+            lowercase_symbol = line.split()[0]
+            symbols.append(lowercase_symbol[0].upper() + lowercase_symbol[1:])
             positions.append([float(x) for x in line.split()[1:]])
     return centers, Atoms(symbols=symbols, positions=positions, pbc=True)
 

--- a/src/koopmans/workflows/_convergence.py
+++ b/src/koopmans/workflows/_convergence.py
@@ -355,7 +355,7 @@ class ConvergenceWorkflow(Workflow[ConvergenceOutputs]):
                     # self.parameters.orbital_groups = master_orbital_groups + \
                     #     [master_orbital_groups[-1]
                     #         for _ in range(extra_orbitals)]
-                    # utils.write_alpha_file(directory=Path(), alphas=alphas, filling=filling)
+                    # utils.write_alpha_files(directory=Path(), alphas=alphas, filling=filling)
 
                 # Perform calculation
                 subwf.name += label

--- a/src/koopmans/workflows/_koopmans_dfpt.py
+++ b/src/koopmans/workflows/_koopmans_dfpt.py
@@ -257,8 +257,10 @@ class KoopmansDFPTWorkflow(Workflow[KoopmansDFPTOutputs]):
             else:
                 # Load the alphas
                 if self.parameters.alpha_from_file:
-                    alpha_file = LocalFile("file_alpharef.txt")
-                    self.bands.alphas = [utils.read_alpha_file(alpha_file)]
+                    alpha_file_occ = LocalFile("file_alpharef.txt")
+                    alpha_file_empty = LocalFile("file_alpharef.txt")
+                    self.bands.alphas = [utils.read_alpha_file(alpha_file_occ)
+                                         + utils.read_alpha_file(alpha_file_empty)]
                 else:
                     self.bands.alphas = self.parameters.alpha_guess
 

--- a/src/koopmans/workflows/_koopmans_dfpt.py
+++ b/src/koopmans/workflows/_koopmans_dfpt.py
@@ -1,6 +1,5 @@
 """The workflow for performing KI and KIPZ calculations with kcw.x."""
 
-from pathlib import Path
 from typing import Dict, List, Optional
 
 import numpy as np
@@ -9,7 +8,7 @@ from koopmans import pseudopotentials, utils
 from koopmans.bands import Bands
 from koopmans.calculators import (KoopmansHamCalculator, PWCalculator,
                                   Wann2KCCalculator, Wannier90Calculator)
-from koopmans.files import File
+from koopmans.files import File, LocalFile
 from koopmans.process_io import IOModel
 from koopmans.projections import BlockID
 from koopmans.status import Status
@@ -258,7 +257,8 @@ class KoopmansDFPTWorkflow(Workflow[KoopmansDFPTOutputs]):
             else:
                 # Load the alphas
                 if self.parameters.alpha_from_file:
-                    self.bands.alphas = [utils.read_alpha_file(Path())]
+                    alpha_file = LocalFile("file_alpharef.txt")
+                    self.bands.alphas = [utils.read_alpha_file(alpha_file)]
                 else:
                     self.bands.alphas = self.parameters.alpha_guess
 

--- a/src/koopmans/workflows/_koopmans_dscf.py
+++ b/src/koopmans/workflows/_koopmans_dscf.py
@@ -234,10 +234,10 @@ class KoopmansDSCFWorkflow(Workflow[KoopmansDSCFOutputs]):
     def read_alphas_from_file(self, directory: Path = Path()):
         """Read the contents of `file_alpharef.txt` and `file_alpharef_empty.txt`.
 
-        Since utils.read_alpha_file provides a flattened list of alphas so we must convert this
+        Since utils.read_alpha_files provides a flattened list of alphas so we must convert this
         to a nested list using convert_flat_alphas_for_kcp()
         """
-        flat_alphas = utils.read_alpha_file(self)
+        flat_alphas = utils.read_alpha_files(self)
         params = self.calculator_parameters['kcp']
         assert isinstance(params, KoopmansCPSettingsDict)
         alphas = convert_flat_alphas_for_kcp(flat_alphas, params)


### PR DESCRIPTION
Fixes a bug in the code when running a DFPT calculation and reading the screening parameters from file (instead of calculating them ab initio).