### PR TITLE
More flexible command configuration

### DIFF
--- a/src/koopmans/base.py
+++ b/src/koopmans/base.py
@@ -1,0 +1,12 @@
+"""Pydantic base model to use throughout `koopmans`."""
+
+from pydantic import BaseModel as _BaseModel
+from pydantic import ConfigDict
+
+
+class BaseModel(_BaseModel):
+    """Base model with a modified default configuration."""
+
+    model_config = ConfigDict(extra="forbid",
+                              arbitrary_types_allowed=True,
+                              validate_assignment=True)

--- a/src/koopmans/calculators/_calculator.py
+++ b/src/koopmans/calculators/_calculator.py
@@ -68,6 +68,7 @@ class CalculatorExt(utils.HasDirectory):
     ext_in: str = ''
     ext_out: str = ''
     parent_process: Workflow | None
+    code: str = ''
 
     def __init__(self, parent_process=None, engine=None, skip_qc: bool = False, **kwargs: Any):
         super().__init__(parent_process=parent_process, engine=engine)
@@ -205,9 +206,6 @@ class CalculatorExt(utils.HasDirectory):
         if self.directory.exists():
             utils.remove(self.directory)
 
-        # By default, check the corresponding program is installed
-        self.check_code_is_installed()
-
         # Copy over all files linked to this calculation
         self._fetch_linked_files()
 
@@ -248,18 +246,6 @@ class CalculatorExt(utils.HasDirectory):
             # Some calculators (e.g. wann2kc) can't reconstruct atoms from an input file
             self.atoms = calc.atoms
             self.atoms.calc = self
-
-    def check_code_is_installed(self):
-        """Check that the corresponding code is installed."""
-        if self.command.path == Path():
-            executable_with_path = utils.find_executable(self.command.executable)
-            if executable_with_path is None:
-                raise OSError(f'`{self.command.executable}` is not installed')
-            self.command.path = executable_with_path.parent
-        else:
-            if not (self.command.path / self.command.executable).is_file():
-                raise OSError(f'`{self.command.executable}` is not installed')
-        return
 
     def write_alphas(self):
         """Write the screening parameters to a file."""

--- a/src/koopmans/calculators/_koopmans_cp.py
+++ b/src/koopmans/calculators/_koopmans_cp.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import copy
 import math
-import os
 import pickle
 import xml.etree.ElementTree as ET
 from pathlib import Path
@@ -18,7 +17,6 @@ from scipy.linalg import block_diag
 
 from koopmans import bands, pseudopotentials, settings, utils
 from koopmans.cell import cell_follows_qe_conventions, cell_to_parameters
-from koopmans.commands import ParallelCommand
 from koopmans.files import File
 
 from ._calculator import (CalculatorABC, CalculatorCanEnforceSpinSym,
@@ -82,6 +80,7 @@ class KoopmansCPCalculator(CalculatorCanEnforceSpinSym, CalculatorExt, Espresso_
 
     ext_in = '.cpi'
     ext_out = '.cpo'
+    code = 'kcp'
 
     def __init__(self, atoms: Atoms, alphas: Optional[List[List[float]]] = None,
                  filling: Optional[List[List[bool]]] = None, **kwargs):
@@ -103,9 +102,6 @@ class KoopmansCPCalculator(CalculatorCanEnforceSpinSym, CalculatorExt, Espresso_
                 self.parameters.nelup = self.parameters.nelec // 2
             if 'neldw' not in self.parameters:
                 self.parameters.neldw = self.parameters.nelec // 2
-
-        if not isinstance(self.command, ParallelCommand):
-            self.command = ParallelCommand(os.environ.get('ASE_ESPRESSO_KCP_COMMAND', self.command))
 
         if alphas is not None:
             self.alphas = alphas

--- a/src/koopmans/calculators/_koopmans_ham.py
+++ b/src/koopmans/calculators/_koopmans_ham.py
@@ -8,7 +8,6 @@ from ase_koopmans.calculators.espresso import KoopmansHam
 from ase_koopmans.dft.kpoints import BandPath
 
 from koopmans import settings, utils
-from koopmans.commands import ParallelCommand
 
 from ._calculator import CalculatorABC, KCWannCalculator, ReturnsBandStructure
 
@@ -18,6 +17,7 @@ class KoopmansHamCalculator(KCWannCalculator, KoopmansHam, ReturnsBandStructure,
 
     ext_in = '.khi'
     ext_out = '.kho'
+    code = "kcw_ham"
 
     def __init__(self, atoms: Atoms, alphas: Optional[List[float]] = None, *args, **kwargs):
         # Define the valid settings
@@ -26,8 +26,6 @@ class KoopmansHamCalculator(KCWannCalculator, KoopmansHam, ReturnsBandStructure,
         # Initialize using the ASE parent, and then CalculatorExt
         KoopmansHam.__init__(self, atoms=atoms)
         KCWannCalculator.__init__(self, *args, **kwargs)
-
-        self.command = ParallelCommand(f'kcw.x -in PREFIX{self.ext_in} > PREFIX{self.ext_out} 2>&1')
 
         # Store the alphas
         self.alphas = alphas

--- a/src/koopmans/calculators/_koopmans_screen.py
+++ b/src/koopmans/calculators/_koopmans_screen.py
@@ -5,7 +5,6 @@ from ase_koopmans import Atoms
 from ase_koopmans.calculators.espresso import KoopmansScreen
 
 from koopmans import settings, utils
-from koopmans.commands import ParallelCommandWithPostfix
 
 from ._calculator import CalculatorABC, KCWannCalculator
 
@@ -15,6 +14,7 @@ class KoopmansScreenCalculator(KCWannCalculator, KoopmansScreen, CalculatorABC):
 
     ext_in = '.ksi'
     ext_out = '.kso'
+    code = "kcw_screen"
 
     def __init__(self, atoms: Atoms, *args, **kwargs):
         # Define the valid settings
@@ -24,8 +24,6 @@ class KoopmansScreenCalculator(KCWannCalculator, KoopmansScreen, CalculatorABC):
         KoopmansScreen.__init__(self, atoms=atoms)
         KCWannCalculator.__init__(self, *args, **kwargs)
         super().__init__(*args, **kwargs)
-
-        self.command = ParallelCommandWithPostfix(f'kcw.x -in PREFIX{self.ext_in} > PREFIX{self.ext_out} 2>&1')
 
     def _pre_calculate(self):
         # Check eps infinity

--- a/src/koopmans/calculators/_ph.py
+++ b/src/koopmans/calculators/_ph.py
@@ -4,7 +4,6 @@ import numpy as np
 from ase_koopmans import Atoms
 from ase_koopmans.calculators.espresso import EspressoPh
 
-from koopmans.commands import ParallelCommand
 from koopmans.settings import PhSettingsDict
 
 from ._calculator import CalculatorABC, CalculatorExt
@@ -15,6 +14,7 @@ class PhCalculator(CalculatorExt, EspressoPh, CalculatorABC):
 
     ext_in = '.phi'
     ext_out = '.pho'
+    code = "ph"
 
     def __init__(self, atoms: Atoms, *args, **kwargs):
         self.parameters = PhSettingsDict()
@@ -23,8 +23,6 @@ class PhCalculator(CalculatorExt, EspressoPh, CalculatorABC):
         # Initialise first using the ASE parent and then CalculatorExt
         EspressoPh.__init__(self, atoms=atoms)
         CalculatorExt.__init__(self, *args, **kwargs)
-
-        self.command = ParallelCommand(f'ph.x -in PREFIX{self.ext_in} > PREFIX{self.ext_out} 2>&1')
 
     def is_converged(self):
         """Return True; a ph calculation is never not "converged"."""

--- a/src/koopmans/calculators/_projwfc.py
+++ b/src/koopmans/calculators/_projwfc.py
@@ -1,7 +1,6 @@
 """projwfc.x calculator module for koopmans."""
 
 import copy
-import os
 import re
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -14,7 +13,6 @@ from ase_koopmans.spectrum.dosdata import GridDOSData
 from upf_tools import UPFDict
 
 from koopmans import pseudopotentials
-from koopmans.commands import Command, ParallelCommand
 from koopmans.files import File
 from koopmans.settings import ProjwfcSettingsDict
 
@@ -26,6 +24,7 @@ class ProjwfcCalculator(CalculatorExt, Projwfc, CalculatorABC):
 
     ext_in = '.pri'
     ext_out = '.pro'
+    code = "projwfc"
 
     def __init__(self, atoms: Atoms, *args, **kwargs):
         # Define the valid settings
@@ -35,9 +34,6 @@ class ProjwfcCalculator(CalculatorExt, Projwfc, CalculatorABC):
         # Initialize first using the ASE parent and then CalculatorExt
         Projwfc.__init__(self, atoms=atoms)
         CalculatorExt.__init__(self, *args, **kwargs)
-
-        if not isinstance(self.command, Command):
-            self.command = ParallelCommand(os.environ.get('ASE_PROJWFC_COMMAND', self.command))
 
         # We need pseudopotentials and pseudo dir in order to work out the number of valence electrons for each
         # element, and therefore what pDOS files to expect. We also need spin-polarized to know if the pDOS files will

--- a/src/koopmans/calculators/_pw.py
+++ b/src/koopmans/calculators/_pw.py
@@ -1,14 +1,11 @@
 """pw calculator module for koopmans."""
 
-import os
-
 import numpy as np
 from ase_koopmans import Atoms
 from ase_koopmans.calculators.espresso import Espresso
 from ase_koopmans.dft.kpoints import BandPath
 
 from koopmans.cell import cell_follows_qe_conventions, cell_to_parameters
-from koopmans.commands import Command, ParallelCommandWithPostfix
 from koopmans.settings import PWSettingsDict
 
 from ._calculator import CalculatorABC, CalculatorExt, ReturnsBandStructure
@@ -19,6 +16,7 @@ class PWCalculator(CalculatorExt, Espresso, ReturnsBandStructure, CalculatorABC)
 
     ext_in = '.pwi'
     ext_out = '.pwo'
+    code = "pw"
 
     def __init__(self, atoms: Atoms, *args, **kwargs):
         # Define the valid settings
@@ -27,10 +25,6 @@ class PWCalculator(CalculatorExt, Espresso, ReturnsBandStructure, CalculatorABC)
         # Initialize first using the ASE parent and then CalculatorExt
         Espresso.__init__(self, atoms=atoms)
         CalculatorExt.__init__(self, *args, **kwargs)
-
-        if not isinstance(self.command, Command):
-            self.command = ParallelCommandWithPostfix(os.environ.get(
-                'ASE_ESPRESSO_COMMAND', self.command))
 
     def _pre_calculate(self):
         # Update ibrav and celldms

--- a/src/koopmans/calculators/_pw2wannier.py
+++ b/src/koopmans/calculators/_pw2wannier.py
@@ -1,11 +1,8 @@
 """pw2wannier calculator module for koopmans."""
 
-import os
-
 from ase_koopmans import Atoms
 from ase_koopmans.calculators.espresso import PW2Wannier
 
-from koopmans.commands import ParallelCommand
 from koopmans.settings import PW2WannierSettingsDict
 
 from ._calculator import CalculatorABC, CalculatorExt
@@ -16,6 +13,7 @@ class PW2WannierCalculator(CalculatorExt, PW2Wannier, CalculatorABC):
 
     ext_in = '.p2wi'
     ext_out = '.p2wo'
+    code = "pw2wannier90"
 
     def __init__(self, atoms: Atoms, *args, **kwargs):
         self.parameters = PW2WannierSettingsDict()
@@ -23,8 +21,6 @@ class PW2WannierCalculator(CalculatorExt, PW2Wannier, CalculatorABC):
         # Initialize first using the ASE parent and then CalculatorExt
         PW2Wannier.__init__(self, atoms=atoms)
         CalculatorExt.__init__(self, *args, **kwargs)
-
-        self.command = ParallelCommand(os.environ.get('ASE_PW2WANNIER_COMMAND', self.command))
 
     def is_converged(self):
         """Return True; a PW2Wannier calculation is never not "converged"."""

--- a/src/koopmans/calculators/_wann2kc.py
+++ b/src/koopmans/calculators/_wann2kc.py
@@ -3,7 +3,6 @@
 from ase_koopmans import Atoms
 from ase_koopmans.calculators.espresso import Wann2KC
 
-from koopmans.commands import ParallelCommandWithPostfix
 from koopmans.settings import Wann2KCSettingsDict
 
 from ._calculator import CalculatorABC, KCWannCalculator
@@ -14,6 +13,7 @@ class Wann2KCCalculator(KCWannCalculator, Wann2KC, CalculatorABC):
 
     ext_in = '.w2ki'
     ext_out = '.w2ko'
+    code = "kcw_wannier"
 
     def __init__(self, atoms: Atoms, *args, **kwargs):
         # Define the valid settings
@@ -22,8 +22,6 @@ class Wann2KCCalculator(KCWannCalculator, Wann2KC, CalculatorABC):
         # Initialize first using the ASE parent and then CalculatorExt
         Wann2KC.__init__(self, atoms=atoms)
         KCWannCalculator.__init__(self, *args, **kwargs)
-
-        self.command = ParallelCommandWithPostfix(f'kcw.x -in PREFIX{self.ext_in} > PREFIX{self.ext_out} 2>&1')
 
     def is_converged(self):
         """Return True; a Wann2KC calculation is never not "converged"."""

--- a/src/koopmans/calculators/_wann2kcp.py
+++ b/src/koopmans/calculators/_wann2kcp.py
@@ -1,11 +1,8 @@
 """wann2kcp calculator module for koopmans."""
 
-import os
-
 from ase_koopmans import Atoms
 from ase_koopmans.calculators.espresso import Wann2KCP
 
-from koopmans.commands import ParallelCommand
 from koopmans.settings import Wann2KCPSettingsDict
 
 from ._calculator import CalculatorABC, CalculatorExt
@@ -16,6 +13,7 @@ class Wann2KCPCalculator(CalculatorExt, Wann2KCP, CalculatorABC):
 
     ext_in = '.wki'
     ext_out = '.wko'
+    code = "wann2kcp"
 
     def __init__(self, atoms: Atoms, *args, **kwargs):
         self.parameters = Wann2KCPSettingsDict()
@@ -23,8 +21,6 @@ class Wann2KCPCalculator(CalculatorExt, Wann2KCP, CalculatorABC):
         # Initialize first using the ASE parent and then CalculatorExt
         Wann2KCP.__init__(self, atoms=atoms)
         CalculatorExt.__init__(self, *args, **kwargs)
-
-        self.command = ParallelCommand(os.environ.get('ASE_WANN2KCP_COMMAND', self.command))
 
     def is_converged(self):
         """Return True; a Wann2KCP calculation is never not "converged"."""

--- a/src/koopmans/calculators/_wannier90.py
+++ b/src/koopmans/calculators/_wannier90.py
@@ -1,11 +1,8 @@
 """wannier90 calculator module for koopmans."""
 
-import os
-
 from ase_koopmans import Atoms
 from ase_koopmans.calculators.wannier90 import Wannier90
 
-from koopmans.commands import Command
 from koopmans.settings import Wannier90SettingsDict
 from koopmans.utils import CalculatorNotConvergedWarning, warn
 
@@ -17,6 +14,7 @@ class Wannier90Calculator(CalculatorExt, Wannier90, CalculatorABC):
 
     ext_in = '.win'
     ext_out = '.wout'
+    code = "wannier90"
 
     def __init__(self, atoms: Atoms, *args, **kwargs):
         # Define the list of parameters
@@ -25,9 +23,6 @@ class Wannier90Calculator(CalculatorExt, Wannier90, CalculatorABC):
         # Initialize first using the ASE parent and then CalculatorExt
         Wannier90.__init__(self, atoms=atoms)
         CalculatorExt.__init__(self, *args, **kwargs)
-
-        # Set up the command for running this calculator
-        self.command = Command(os.environ.get('ASE_WANNIER90_COMMAND', self.command))
 
     def is_converged(self):
         """Return True if the calculation is converged."""

--- a/src/koopmans/commands.py
+++ b/src/koopmans/commands.py
@@ -1,149 +1,468 @@
-"""Defines a "Command" class in place of storing these simply as strings."""
-
-from __future__ import annotations
+"""Pydantic models that define the configurations of commands."""
 
 import os
-from pathlib import Path
-from typing import Optional, Union
+from abc import ABC, abstractmethod
+from typing import Any, ClassVar
+
+from pydantic import Field, field_validator, model_validator
+from typing_extensions import Self
+
+from koopmans.base import BaseModel
 
 
-class Command(object):
-    """A class for storing commands.
-
-    It has the attributes...
-        Command.path
-        Command.executable
-        Command.flags
-        Command.suffix
-    """
-
-    def __init__(self, value: Optional[Union[str, Command]] = None, **kwargs) -> None:
-        self._path = Path()
-        self.executable: str = ''
-        self._flags: str = ''
-        self.suffix: str = ''
-
-        if isinstance(value, Command):
-            value = str(value)
-        if value is not None:
-            self.__set__(value)
-
-        # Accepts setting of public attributes as kwargs
-        for k, v in kwargs.items():
-            assert hasattr(self, k), f'Unrecognized argument {k} provided to {self.__class__.__name__}'
-            assert not k.startswith(
-                '_'), f'Do not attempt to set private variables via {self.__class__.__name__}.__init__()'
-            setattr(self, k, v)
-
-    def __set__(self, value: str):
-        self.flags = ''
-        if isinstance(value, str):
-            if value.startswith(('srun', 'mpirun')):
-                raise ValueError(
-                    f'You tried to set the command for the serial calculator `{self.__class__.__name__} '
-                    'with an MPI call')
-            [path_plus_executable, self.suffix] = value.split(' ', 1)
-            if '/' in path_plus_executable:
-                path, self.executable = path_plus_executable.rsplit('/', 1)
-                self.path = Path(path)
-            else:
-                self.executable = path_plus_executable
-                self.path = Path()
+def _redirection_string(stdin: str, stdout: str | None, stderr: None | str = None,
+                        stdin_redirection_string: str = "<") -> str:
+    redirection = f"{stdin_redirection_string} {stdin}"
+    if stdout is not None:
+        redirection += f" > {stdout}"
+        if stderr is not None:
+            redirection += f" 2> {stderr}"
         else:
-            raise NotImplementedError(f'`{self.__class__.__name__}` must be set via a string')
+            redirection += " 2>&1"
+    return redirection
 
-    def __repr__(self):
-        return ' '.join([str(self.path / self.executable), self.flags, self.suffix]).replace('  ', ' ')
+
+def para_prefix_to_dict(para_prefix: str) -> dict[str, str | None | int]:
+    """Extract the MPI executable and number of tasks from the PARA_PREFIX string."""
+    parts = para_prefix.split(" ")
+    if len(parts) == 3:
+        [mpi_executable, _, num_tasks_str] = parts
+        num_tasks = int(num_tasks_str)
+    elif len(parts) == 1:
+        mpi_executable = parts[0]
+        num_tasks = None
+    else:
+        raise ValueError(
+            f"Invalid PARA_PREFIX string `{para_prefix}`\nExpected something of the format "
+            "`<mpi_executable> -n <num_tasks>` or `<mpi_executable>`")
+
+    return {
+        "mpi_executable": mpi_executable,
+        "num_tasks": num_tasks,
+    }
+
+
+def command_string_to_dict(command_string: str) -> dict[str, Any]:
+    """Convert a command string into a dictionary of its constituent parts."""
+    # Split the string into parts
+    parts = command_string.split(" ")[::-1]
+    stdout = None
+    stderr = None
+    options: dict[str, Any] = {}
+    try:
+        executable = parts.pop()
+
+        # Command-line options
+        while parts[-1].startswith("-"):
+            if parts[-1] == "-in":
+                break
+            key = parts.pop().strip('-')
+            value: Any
+            if parts[-1].startswith("-") or parts[-1] == "<" or len(parts) < 2 or parts[-2] == ">":
+                # This must be a boolean flag
+                value = True
+            else:
+                value = parts.pop().strip('.')
+            options[key] = value
+        if parts[-1] in ["-in", "<"]:
+            stdin_redirection_string = parts.pop()
+        else:
+            stdin_redirection_string = ""
+        stdin = parts.pop()
+        if parts and parts.pop() == ">":
+            stdout = parts.pop()
+            if parts and parts[-1] == "2>&1":
+                stderr = None
+            elif parts.pop() == "2>":
+                stderr = parts.pop()
+    except IndexError:
+        raise ValueError(
+            f"Invalid string `{command_string}`\nExpected something of the format `<executable> "
+            "(-<flag> <value>) <stdin_redirection> <stdin> > <stdout> 2>&1` or `2> <stderr>`")
+
+    return {
+        "executable": executable,
+        "stdin": stdin,
+        "stdout": stdout,
+        "stderr": stderr,
+        "stdin_redirection_string": stdin_redirection_string} | options
+
+
+class CommandConfig(BaseModel, ABC):
+    """Abstract base class for a command configuration."""
+
+    executable: str = Field(..., description="Path to the command executable.")
+    stdin: str = Field(..., description="Input file for the command.")
+    stdout: str | None = Field(None, description="Output file for the command.")
+    stderr: str | None = Field(None, description="Error file for the command.")
+    stdin_redirection_string: ClassVar[str] = "<"
+    ase_env_var: ClassVar[str] = "ASE_COMMAND"
 
     @property
-    def path(self) -> Path:
-        """The path of the executable."""
-        return self._path
-
-    @path.setter
-    def path(self, value: Union[Path, str]):
-        self._path = Path(value)
+    @abstractmethod
+    def options_str(self) -> str:
+        """Return the string of options to provide to the executable."""
 
     @property
-    def flags(self) -> str:
-        """Return any flags that should be passed to the executable."""
-        return self._flags
+    def redirection_string(self) -> str:
+        """Return the string of redirection to provide to the executable."""
+        return _redirection_string(
+            self.stdin, self.stdout, self.stderr, self.stdin_redirection_string
+        )
 
-    @flags.setter
-    def flags(self, value: str):
-        self._flags = value
+    def command(self, additional_flags: list[str] = [], additional_options: dict[str, str] = {}) -> str:
+        """Return the string of the command to run."""
+        additional_options_str = ' '.join([f"{k} {v}" for k, v in additional_options.items()])
 
-    def todict(self):
-        """Convert the Command object to a dictionary."""
-        dct = self.__dict__.copy()
-        dct['__koopmans_name__'] = self.__class__.__name__
-        dct['__koopmans_module__'] = self.__class__.__module__
-        return dct
+        command_str = (f"{self.executable} {self.options_str} {' '.join(additional_flags)} "
+                       f"{additional_options_str} {self.redirection_string}")
+
+        while '  ' in command_str:
+            command_str = command_str.replace('  ', ' ')
+
+        return command_str.strip()
 
     @classmethod
-    def fromdict(cls, dct):
-        """Construct a Command object from a dictionary."""
-        command = cls(**{k.lstrip('_'): v for k, v in dct.items()})
-        return command
+    def from_string(cls, value: str, **kwargs: Any) -> Self:
+        """Create a CommandConfig object from a string."""
+        kwargs.update(command_string_to_dict(value))
+        stdin_redirect = kwargs.pop("stdin_redirection_string")
+        if stdin_redirect != cls.stdin_redirection_string:
+            raise ValueError(
+                f"Redirection string `{stdin_redirect}` does not match expected `{cls.stdin_redirection_string}`")
 
-    def __eq__(self, other):
-        return self.__dict__ == other.__dict__
+        return cls(**kwargs)
+
+    @classmethod
+    def from_env(cls) -> Self:
+        """Create a CommandConfig based on the corresponding environment variable."""
+        env_var = os.environ.get(cls.ase_env_var)
+        if env_var is None:
+            raise OSError(f"Environment variable `{cls.ase_env_var}` not set")
+        return cls.from_string(env_var)
 
 
-class ParallelCommand(Command):
-    """An extension to the Command class for mpi-parallelized executables."""
+class ParallelCommandConfig(CommandConfig, ABC):
+    """Abstract base class for a command configuration that can be run in parallel."""
 
-    def __init__(self, *args, **kwargs) -> None:
-        self.mpi_command: str = ''
-        super().__init__(*args, **kwargs)
+    mpi_executable: str = Field("mpirun", description="MPI executable to use for parallel execution.")
+    num_tasks: int | None = Field(None, description="Number of tasks to run in parallel.")
 
-    def __set__(self, value: str):
-        if isinstance(value, str):
-            default_mpi_command = os.environ.get('PARA_PREFIX', None)
-            if value.startswith('srun') or value.startswith('mpirun'):
-                splitval = value.split()
-
-                i_command = None
-                for i, val in enumerate(splitval[1:]):
-                    prev_val = splitval[i]
-                    if val.startswith('-'):
-                        continue
-                    elif prev_val.startswith('-') and '=' not in prev_val:
-                        continue
-                    else:
-                        i_command = i + 1
-                        break
-                if i_command is None:
-                    raise ValueError(f'Failed to parse `{value}`')
-
-                self.mpi_command = ' '.join(splitval[:i_command])
-                rest_of_command = ' '.join(splitval[i_command:])
-            elif default_mpi_command is not None:
-                self.mpi_command = default_mpi_command
-                rest_of_command = value
-            else:
-                self.mpi_command = ''
-                rest_of_command = value
-            super().__set__(rest_of_command)
+    def command(self, additional_flags: list[str] = [], additional_options: dict[str, str] = {}) -> str:
+        """Return the string of the command to run."""
+        if self.num_tasks == 1:
+            prefix = ""
         else:
-            raise NotImplementedError(f'`{self.__class__.__name__}` must be set via a string')
+            ntasks_str = f" -n {self.num_tasks}" if self.num_tasks is not None else ""
+            prefix = f"{self.mpi_executable}{ntasks_str} "
+        return prefix + super().command(additional_flags, additional_options)
 
-    def __repr__(self) -> str:
-        return self.mpi_command + ' ' + super().__repr__()
+    @classmethod
+    def from_string(cls, value: str, **kwargs: Any) -> Self:
+        """Create a ParallelCommandConfig object from a string."""
+        if value.split(" ")[0] not in ["srun", "mpirun"]:
+            mpi_executable = "mpirun"
+            num_tasks = 1
+            rest = value
+        elif value.split(" ")[1] not in ["-n", "--np"]:
+            mpi_executable, rest = value.split(" ", 1)
+            num_tasks = None
+        else:
+            mpi_executable, _, num_tasks_str, rest = value.split(" ", 3)
+            num_tasks = int(num_tasks_str)
+
+        kwargs["mpi_executable"] = mpi_executable
+        kwargs["num_tasks"] = num_tasks
+
+        return super(ParallelCommandConfig, cls).from_string(rest, **kwargs)
 
 
-class ParallelCommandWithPostfix(ParallelCommand):
-    """An extension to the Parallel Command class that supports Quantum ESPRESSO's $PARA_POSTFIX."""
+class KCWHamConfig(ParallelCommandConfig):
+    """Configuration for the kcw.x command."""
+
+    executable: str = "kcw.x"
+    stdin: str = "PREFIX.khi"
+    stdout: str | None = "PREFIX.kho"
+    stderr: str | None = None
+    stdin_redirection_string: ClassVar[str] = "-in"
+    ase_env_var: ClassVar[str] = "ASE_KCW_HAM_COMMAND"
 
     @property
-    def flags(self) -> str:
-        """Return any flags that should be passed to the executable."""
-        return (self.postfix + ' ' + self._flags).strip()
+    def options_str(self) -> str:
+        """Return the string of options to provide to the executable."""
+        return ''
 
-    @flags.setter
-    def flags(self, value: str):
-        self._flags = value
 
-    def __init__(self, *args, **kwargs):
-        self.postfix = os.environ.get('PARA_POSTFIX', '')
-        super().__init__(*args, **kwargs)
+class KCWScreenConfig(ParallelCommandConfig):
+    """Configuration for the kcw.x command."""
+
+    executable: str = "kcw.x"
+    stdin: str = "PREFIX.ksi"
+    stdout: str | None = "PREFIX.kso"
+    stderr: str | None = None
+    stdin_redirection_string: ClassVar[str] = "-in"
+    ase_env_var: ClassVar[str] = "ASE_KCW_SCREEN_COMMAND"
+
+    @property
+    def options_str(self) -> str:
+        """Return the string of options to provide to the executable."""
+        return ''
+
+
+class KCWWannierConfig(ParallelCommandConfig):
+    """Configuration for the kcw.x command."""
+
+    executable: str = "kcw.x"
+    stdin: str = "PREFIX.w2ki"
+    stdout: str | None = "PREFIX.w2ko"
+    stderr: str | None = None
+    stdin_redirection_string: ClassVar[str] = "-in"
+    ase_env_var: ClassVar[str] = "ASE_KCW_WANNIER_COMMAND"
+
+    @property
+    def options_str(self) -> str:
+        """Return the string of options to provide to the executable."""
+        return ''
+
+
+class KCPConfig(ParallelCommandConfig):
+    """Configuration for the kcp.x command."""
+
+    executable: str = "kcp.x"
+    stdin: str = "PREFIX.cpi"
+    stdout: str | None = "PREFIX.cpo"
+    stderr: str | None = None
+    stdin_redirection_string: ClassVar[str] = "-in"
+    ase_env_var: ClassVar[str] = "ASE_KCP_COMMAND"
+
+    @property
+    def options_str(self) -> str:
+        """Return the string of options to provide to the executable."""
+        return ''
+
+
+class PhConfig(ParallelCommandConfig):
+    """Configuration for the ph.x command."""
+
+    executable: str = "ph.x"
+    stdin: str = "PREFIX.phi"
+    stdout: str | None = "PREFIX.pho"
+    stderr: str | None = None
+    stdin_redirection_string: ClassVar[str] = "-in"
+    ase_env_var: ClassVar[str] = "ASE_PH_COMMAND"
+
+    @property
+    def options_str(self) -> str:
+        """Return the string of options to provide to the executable."""
+        return ''
+
+
+class ProjwfcConfig(ParallelCommandConfig):
+    """Configuration for the projwfc.x command."""
+
+    executable: str = "projwfc.x"
+    stdin: str = "PREFIX.pri"
+    stdout: str | None = "PREFIX.pro"
+    stderr: str | None = None
+    stdin_redirection_string: ClassVar[str] = "-in"
+    ase_env_var: ClassVar[str] = "ASE_PROJWFC_COMMAND"
+
+    @property
+    def options_str(self) -> str:
+        """Return the string of options to provide to the executable."""
+        return ''
+
+
+class Wann2KCPConfig(ParallelCommandConfig):
+    """Configuration for the wann2kcp.x command."""
+
+    executable: str = "wann2kcp.x"
+    stdin: str = "PREFIX.wki"
+    stdout: str | None = None
+    stderr: str | None = None
+    stdin_redirection_string: ClassVar[str] = ""
+    ase_env_var: ClassVar[str] = "ASE_WANN2KCP_COMMAND"
+
+    @property
+    def options_str(self) -> str:
+        """Return the string of options to provide to the executable."""
+        return ''
+
+
+class PWConfig(ParallelCommandConfig):
+    """Configuration for the pw.x command."""
+
+    executable: str = "pw.x"
+    stdin: str = "PREFIX.pwi"
+    stdout: str | None = "PREFIX.pwo"
+    stderr: str | None = None
+    stdin_redirection_string: ClassVar[str] = "-in"
+    npool: int | None = Field(None, description="Number of pools to use for parallel execution.")
+    pd: bool = Field(False, description="Use pencil decomposition.")
+    ase_env_var: ClassVar[str] = "ASE_PW_COMMAND"
+
+    @property
+    def options_str(self) -> str:
+        """Return the string of options to provide to the executable."""
+        options: list[str] = []
+        if self.npool is not None:
+            options.append(f"-npool {self.npool}")
+        if self.pd:
+            options.append(f"-pd {self.pd}")
+        return ' '.join(options)
+
+
+class PW2Wannier90Config(ParallelCommandConfig):
+    """Configuration for the pw2wannier90.x command."""
+
+    executable: str = "pw2wannier90.x"
+    stdin: str = "PREFIX.p2wi"
+    stdout: str | None = "PREFIX.p2wo"
+    stderr: str | None = None
+    stdin_redirection_string: ClassVar[str] = "-in"
+    pd: bool = Field(False, description="Use pencil decomposition.")
+    ase_env_var: ClassVar[str] = "ASE_PW2WANNIER90_COMMAND"
+
+    @property
+    def options_str(self) -> str:
+        """Return the string of options to provide to the executable."""
+        options: list[str] = []
+        if self.pd:
+            options.append(f"-pd {self.pd}")
+        return ' '.join(options)
+
+
+class Wannier90Config(CommandConfig):
+    """Configuration for the wannier90.x command."""
+
+    executable: str = "wannier90.x"
+    stdin: str = "PREFIX.win"
+    stdin_redirection_string: ClassVar[str] = ""
+    pp: bool = Field(False, description="Perform preprocessing.")
+    ase_env_var: ClassVar[str] = "ASE_WANNIER90_COMMAND"
+
+    @field_validator("stdout", mode="after")
+    @classmethod
+    def check_stdout_is_none(cls, value: str | None) -> None:
+        """Check that stdout is None."""
+        if value is not None:
+            raise ValueError("stdout must be None for wannier90.x as it automatically performs redirection.")
+        return value
+
+    @property
+    def options_str(self) -> str:
+        """Return the string of options to provide to the executable."""
+        return '-pp' if self.pp else ''
+
+    @property
+    def redirection_string(self) -> str:
+        """Return the string of redirection to provide to the executable.
+
+        Here we override the default redirection string because Wannier90 automatically
+        performs redirection.
+        """
+        return f"{self.stdin}"
+
+
+class CommandConfigs(BaseModel):
+    """Collection of command configurations.
+
+    Will consult the environment variables `ASE_<CALC_NAME>_COMMAND` to set the default values for each command.
+    """
+
+    mpi_executable: str = Field("mpirun", description="MPI executable to use for parallel execution.")
+    kcw_ham: KCWHamConfig = Field(
+        default_factory=lambda: KCWHamConfig(),
+        description="Configuration for the kcw.x code when running `calculation='ham'`; "
+        "defaults to `ASE_KCW_HAMILTONIAN_COMMAND` if set."
+    )
+    kcw_screen: KCWScreenConfig = Field(
+        default_factory=lambda: KCWScreenConfig(),
+        description="Configuration for the kcw.x code when running `calculation='screen'`; "
+        "defaults to `ASE_KCW_SCREENING_COMMAND` if set."
+    )
+    kcw_wannier: KCWWannierConfig = Field(
+        default_factory=lambda: KCWWannierConfig(),
+        description="Configuration for the kcw.x code when running `calculation='wann2kcw'`; "
+        "defaults to `ASE_KCW_WANNIER_COMMAND` if set."
+    )
+    kcp: KCPConfig = Field(
+        default_factory=lambda: KCPConfig(),
+        description="Configuration for the kcp.x code; defaults to `ASE_KCP_COMMAND` if set."
+    )
+    ph: PhConfig = Field(
+        default_factory=lambda: PhConfig(),
+        description="Configuration for the ph.x code; defaults to `ASE_PH_COMMAND` if set."
+    )
+    projwfc: ProjwfcConfig = Field(
+        default_factory=lambda: ProjwfcConfig(),
+        description="Configuration for the projwfc.x code; defaults to `ASE_PROJWFC_COMMAND` if set."
+    )
+    pw2wannier90: PW2Wannier90Config = Field(
+        default_factory=lambda: PW2Wannier90Config(),
+        description="Configuration for the pw2wannier90.x code; defaults to `ASE_PW2WANNIER90_COMMAND` if set."
+    )
+    pw: PWConfig = Field(
+        default_factory=lambda: PWConfig(),
+        description="Configuration for the pw.x code; defaults to `ASE_PW_COMMAND` if set."
+    )
+    wann2kcp: Wann2KCPConfig = Field(
+        default_factory=lambda: Wann2KCPConfig(),
+        description="Configuration for the wann2kcp.x code; defaults to `ASE_WANN2KCP_COMMAND` if set."
+    )
+    wannier90: Wannier90Config = Field(
+        default_factory=lambda: Wannier90Config(),
+        description="Configuration for the wannier90.x code; defaults to `ASE_WANNIER90_COMMAND` if set."
+    )
+
+    @model_validator(mode="before")
+    def default_mpi_executable(cls, data: dict[str, Any]) -> dict[str, Any]:
+        """Use the provided `mpi_executable` for all codes."""
+        # The default value
+        mpi_executable = cls.__pydantic_fields__['mpi_executable'].default
+
+        # PARA_PREFIX takes precedence over the default value
+        para_prefix = os.environ.get("PARA_PREFIX", None)
+        if para_prefix is not None:
+            mpi_settings = para_prefix_to_dict(para_prefix)
+            mpi_executable = mpi_settings["mpi_executable"]
+            num_tasks = mpi_settings["num_tasks"]
+        else:
+            num_tasks = None
+
+        # Value provided explicitly takes precedence over both
+        provided_mpi_executable = data.get("mpi_executable", None)
+        if provided_mpi_executable is not None:
+            mpi_executable = provided_mpi_executable
+
+        data["mpi_executable"] = mpi_executable
+
+        for name, field in cls.__pydantic_fields__.items():
+            # Check if the field corresponds to a ParallelCommandConfig
+            subclass = field.annotation
+            if subclass is None or not issubclass(subclass, ParallelCommandConfig):
+                continue
+
+            code_settings = data.get(name, {})
+            if isinstance(code_settings, dict):
+                # Only propagate to configurations if they were not provided explicitly or were
+                # provided as a dictionary (in which case the mpi_executable propagation is convenient)
+                data[name] = {"mpi_executable": mpi_executable, "num_tasks": num_tasks} | code_settings
+
+        return data
+
+    @model_validator(mode="before")
+    def get_env_vars(cls, data: dict[str, Any]) -> dict[str, Any]:
+        """Set the configurations based on the corresponding environment variables, if present."""
+        for name, field in cls.__pydantic_fields__.items():
+            # Check if the field corresponds to a CommandConfig
+            subclass = field.annotation
+            if subclass is None or not issubclass(subclass, CommandConfig):
+                continue
+
+            # If the field is not provided, use the environment variable
+            env_var = os.environ.get(subclass.ase_env_var)
+            if env_var is not None and name not in data:
+                data[name] = subclass.from_string(env_var)
+
+        return data

--- a/src/koopmans/engines/engine.py
+++ b/src/koopmans/engines/engine.py
@@ -5,10 +5,12 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Generator, Literal, Optional, overload
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 from upf_tools import UPFDict
 
 from koopmans import utils
+from koopmans.base import BaseModel
+from koopmans.commands import CommandConfigs
 from koopmans.files import File
 from koopmans.processes import ProcessProtocol
 from koopmans.status import Status
@@ -18,7 +20,7 @@ class Engine(BaseModel, ABC):
     """An abstract base class for representing engines that run workflows."""
 
     from_scratch: bool = True
-    npool: Optional[int] = None
+    commands: CommandConfigs = Field(default_factory=lambda: CommandConfigs())
     keep_tmpdirs: bool = True
     statuses: dict[str, Status] = Field(default_factory=dict)
 
@@ -55,7 +57,7 @@ class Engine(BaseModel, ABC):
         self._step_message(uid, '⏭️ ', 'already complete  ')
 
     @abstractmethod
-    def run(self, step: ProcessProtocol) -> None:
+    def run(self, step: ProcessProtocol, additional_flags: list[str] = []) -> None:
         """Run a step of the workflow."""
         ...
 

--- a/src/koopmans/process_io.py
+++ b/src/koopmans/process_io.py
@@ -1,7 +1,8 @@
 """Pydantic model for inputs/outputs of Processes."""
 
 import numpy as np
-from pydantic import BaseModel
+
+from koopmans.base import BaseModel
 
 
 class IOModel(BaseModel):

--- a/src/koopmans/processes/_commandlinetool.py
+++ b/src/koopmans/processes/_commandlinetool.py
@@ -1,17 +1,16 @@
 import subprocess
 from abc import abstractmethod
+from typing import Generic
 
-from koopmans.commands import Command
-
-from ._process import Process
+from ._process import InputModel, OutputModel, Process
 
 
-class CommandLineTool(Process):
+class CommandLineTool(Process[InputModel, OutputModel], Generic[InputModel, OutputModel]):
     """A Process that involves running a command on the command line."""
 
     @property
     @abstractmethod
-    def command(self) -> Command:
+    def command(self) -> str:
         """Return the command the executes the process."""
         ...
 
@@ -23,7 +22,7 @@ class CommandLineTool(Process):
     def _run(self):
         with self.engine.chdir(self.directory):
             # Run the command within self.directory
-            ierr = subprocess.call(str(self.command), shell=True)
+            ierr = subprocess.call(self.command, shell=True)
             if ierr > 0:
                 raise OSError(f'`{self.command}` exited with exit code {ierr}')
         self._set_outputs()

--- a/src/koopmans/processes/bin2xml.py
+++ b/src/koopmans/processes/bin2xml.py
@@ -2,9 +2,6 @@
 
 from pathlib import Path
 
-from pydantic import ConfigDict
-
-from koopmans.commands import Command
 from koopmans.files import File
 from koopmans.process_io import IOModel
 
@@ -15,14 +12,12 @@ class Bin2XMLInput(IOModel):
     """Input for a `Bin2XMLProcess`."""
 
     binary: File
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class Bin2XMLOutput(IOModel):
     """Output for a `Bin2XMLProcess`."""
 
     xml: File
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class Bin2XMLProcess(CommandLineTool):
@@ -43,7 +38,7 @@ class Bin2XMLProcess(CommandLineTool):
     @property
     def command(self):
         """Return the command that this process runs."""
-        return Command(executable='bin2xml.x', suffix='input.dat output.xml')
+        return 'bin2xml.x input.dat output.xml'
 
     def _set_outputs(self):
         xml_filepointer = File(self, Path("output.xml"))

--- a/src/koopmans/processes/koopmans_cp.py
+++ b/src/koopmans/processes/koopmans_cp.py
@@ -3,8 +3,6 @@
 from pathlib import Path
 from typing import List
 
-from pydantic import ConfigDict
-
 from koopmans.files import File
 from koopmans.process_io import IOModel
 
@@ -16,14 +14,12 @@ class ConvertFilesFromSpin2To1InputModel(IOModel):
 
     spin_2_files: List[File]
     spin_1_files: List[Path]
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class ConvertFilesOutputModel(IOModel):
     """Output model for a `ConvertFilesFromSpinXtoY` process."""
 
     generated_files: List[File]
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class ConvertFilesFromSpin2To1(Process[ConvertFilesFromSpin2To1InputModel, ConvertFilesOutputModel]):
@@ -54,7 +50,6 @@ class ConvertFilesFromSpin1To2InputModel(IOModel):
     spin_1_files: List[File]
     spin_2_up_files: List[Path]
     spin_2_down_files: List[Path]
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class ConvertFilesFromSpin1To2(Process[ConvertFilesFromSpin1To2InputModel, ConvertFilesOutputModel]):
@@ -101,14 +96,12 @@ class SwapSpinFilesInputModel(IOModel):
     """Input model for a `SwapSpinFilesProcess`."""
 
     read_directory: File
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class SwapSpinFilesOutputModel(IOModel):
     """Output model for a `SwapSpinFilesProcess`."""
 
     write_directory: File
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class SwapSpinFilesProcess(Process[SwapSpinFilesInputModel, SwapSpinFilesOutputModel]):

--- a/src/koopmans/processes/merge_evc.py
+++ b/src/koopmans/processes/merge_evc.py
@@ -3,7 +3,6 @@
 from typing import List
 
 import numpy as np
-from pydantic import ConfigDict
 
 from koopmans.files import File
 
@@ -17,24 +16,22 @@ class MergeEVCInputs(IOModel):
     kgrid: List[int]
     src_files: List[File]
     dest_filename: str
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class MergeEVCOutputs(IOModel):
     """Output model for a `MergeEVCProcess`."""
 
     merged_file: File
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
-class MergeEVCProcess(CommandLineTool):
+class MergeEVCProcess(CommandLineTool[MergeEVCInputs, MergeEVCOutputs]):
     """Commandline tool for running merge_evc.x."""
 
     input_model = MergeEVCInputs
     output_model = MergeEVCOutputs
 
     @property
-    def command(self):
+    def command(self) -> str:
         """Return the command that this process runs."""
         input_files = [f'input_{i}.dat' for i in range(len(self.inputs.src_files))]
         return ' '.join([f'merge_evc.x -nr {np.prod(self.inputs.kgrid)}']

--- a/src/koopmans/processes/power_spectrum.py
+++ b/src/koopmans/processes/power_spectrum.py
@@ -4,7 +4,6 @@ from typing import List
 
 import numpy as np
 from ase_koopmans.cell import Cell
-from pydantic import ConfigDict
 
 from koopmans import ml
 from koopmans.bands import Band
@@ -26,7 +25,6 @@ class ExtractCoefficientsFromXMLInput(IOModel):
     cell: Cell
     orbital_densities_xml: List[File]
     bands: List[Band]
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class ExtractCoefficientsFromXMLOutput(IOModel):
@@ -36,7 +34,6 @@ class ExtractCoefficientsFromXMLOutput(IOModel):
     precomputed_betas: File
     total_coefficients: List[File]
     orbital_coefficients: List[File]
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class ExtractCoefficientsFromXMLProcess(Process):
@@ -88,14 +85,12 @@ class ComputePowerSpectrumInput(IOModel):
     l_max: int
     orbital_coefficients: File
     total_coefficients: File
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class ComputePowerSpectrumOutput(IOModel):
     """Output model for the `ComputePowerSpectrumProcess`."""
 
     power_spectrum: File
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 def read_coeff_matrix(coeff_orb: np.ndarray, coeff_tot: np.ndarray, n_max: int, l_max: int) -> np.ndarray:

--- a/src/koopmans/processes/ui/_process.py
+++ b/src/koopmans/processes/ui/_process.py
@@ -10,7 +10,7 @@ from ase_koopmans import Atoms
 from ase_koopmans.dft.dos import DOS
 from ase_koopmans.spectrum.band_structure import BandStructure
 from numpy.typing import NDArray
-from pydantic import ConfigDict, Field
+from pydantic import Field
 
 from koopmans import utils
 from koopmans.files import File
@@ -27,7 +27,7 @@ from ._utils import crys_to_cart, extract_hr, latt_vect
 class UnfoldAndInterpolateInputs(IOModel):
     """Input model for the `UnfoldAndInterpolateProcess`."""
 
-    model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
+    model_config = {"frozen": True, **IOModel.model_config}
 
     atoms: UIAtoms = \
         Field(..., description='An ASE Atoms object augmented with supercell information')
@@ -62,7 +62,7 @@ class UnfoldAndInterpolateOutputs(IOModel):
 
     band_structure: BandStructure
     dos: Optional[DOS] = None
-    model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
+    model_config = {"frozen": True, **IOModel.model_config}
 
 
 class UnfoldAndInterpolateProcess(Process[UnfoldAndInterpolateInputs, UnfoldAndInterpolateOutputs]):

--- a/src/koopmans/processes/wannier.py
+++ b/src/koopmans/processes/wannier.py
@@ -6,7 +6,6 @@ from typing import Callable, List
 
 import numpy as np
 from ase_koopmans import Atoms
-from pydantic import ConfigDict
 
 from koopmans import utils
 from koopmans.files import File
@@ -126,14 +125,12 @@ class MergeInputModel(IOModel):
 
     src_files: List[File]
     dst_file: Path
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class MergeOutputModel(IOModel):
     """Output model for a `MergeProcess`."""
 
     dst_file: File
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class MergeProcess(Process):
@@ -165,14 +162,12 @@ class ExtendInputModel(IOModel):
 
     src_file: File
     dst_file: Path
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class ExtendOutputModel(IOModel):
     """Output model for an `ExtendProcess`."""
 
     dst_file: File
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class ExtendProcess(Process):

--- a/src/koopmans/projections.py
+++ b/src/koopmans/projections.py
@@ -6,9 +6,10 @@ from ase_koopmans import Atoms
 from ase_koopmans.io.wannier90 import (list_to_formatted_str,
                                        num_wann_from_projections,
                                        proj_string_to_dict)
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import model_validator
 
 from koopmans import calculators
+from koopmans.base import BaseModel
 from koopmans.utils import SpinOptions, SpinType
 
 
@@ -18,7 +19,7 @@ class BlockID(BaseModel):
     label: Optional[str] = None
     filled: Optional[bool] = None
     spin: SpinType = None
-    model_config = ConfigDict(frozen=True)
+    model_config = {"frozen": True, **BaseModel.model_config}
 
     def __str__(self):
         if self.label is None:

--- a/src/koopmans/workflows/_dft.py
+++ b/src/koopmans/workflows/_dft.py
@@ -135,8 +135,6 @@ class DFTBandsOutput(IOModel):
     band_structure: BandStructure
     dos: DOSCollection | None
 
-    model_config = {'arbitrary_types_allowed': True}
-
 
 class DFTBandsWorkflow(DFTWorkflow[DFTBandsOutput]):
     """Workflow for calculating the band structure and projected density of states using pw.x."""

--- a/src/koopmans/workflows/_folding.py
+++ b/src/koopmans/workflows/_folding.py
@@ -3,8 +3,6 @@
 from pathlib import Path
 from typing import Dict
 
-from pydantic import ConfigDict
-
 from koopmans.files import File
 from koopmans.process_io import IOModel
 from koopmans.processes.merge_evc import MergeEVCProcess
@@ -18,7 +16,6 @@ class FoldToSupercellOutputs(IOModel):
     """Output model for the FoldToSupercellWorkflow."""
 
     kcp_files: Dict[str, File]
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class FoldToSupercellWorkflow(Workflow):

--- a/src/koopmans/workflows/_koopmans_cp_with_spin_swap.py
+++ b/src/koopmans/workflows/_koopmans_cp_with_spin_swap.py
@@ -1,7 +1,5 @@
 """A workflow for managing kcp.x calculations that would want more spin-down electrons than spin-up."""
 
-from pydantic import ConfigDict
-
 from koopmans.calculators import KoopmansCPCalculator
 from koopmans.files import File
 from koopmans.process_io import IOModel
@@ -15,7 +13,6 @@ class KoopmansCPWithSpinSwapOutput(IOModel):
     """Output model for the KoopmansCPWithSpinSwapWorkflow."""
 
     outdir: File
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class KoopmansCPWithSpinSwapWorkflow(Workflow[KoopmansCPWithSpinSwapOutput]):

--- a/src/koopmans/workflows/_koopmans_dscf.py
+++ b/src/koopmans/workflows/_koopmans_dscf.py
@@ -7,7 +7,6 @@ from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 from ase_koopmans.dft import DOS
-from pydantic import ConfigDict
 
 from koopmans import utils
 from koopmans.bands import Band, Bands
@@ -36,7 +35,6 @@ class KoopmansDSCFOutputs(IOModel):
     final_calc: KoopmansCPCalculator
     wannier_hamiltonian_files: Dict[BlockID, File] | None = None
     smooth_dft_ham_files: Dict[BlockID, File] | None = None
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class KoopmansDSCFWorkflow(Workflow[KoopmansDSCFOutputs]):
@@ -394,7 +392,6 @@ class CalculateScreeningViaDSCFOutput(IOModel):
     """Pydantic model for the outputs of a `CalculateScreeningViaDSCF` workflow."""
 
     n_electron_restart_dir: File
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class CalculateScreeningViaDSCF(Workflow[CalculateScreeningViaDSCFOutput]):
@@ -479,7 +476,6 @@ class DeltaSCFIterationOutputs(IOModel):
     converged: bool
     n_electron_restart_dir: File
     dummy_outdirs: Dict[Tuple[int, int], File | None]
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class DeltaSCFIterationWorkflow(Workflow[DeltaSCFIterationOutputs]):
@@ -652,7 +648,6 @@ class OrbitalDeltaSCFOutputs(IOModel):
     alpha: float
     error: float
     dummy_outdir: File | None
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class OrbitalDeltaSCFWorkflow(Workflow[OrbitalDeltaSCFOutputs]):

--- a/src/koopmans/workflows/_ml.py
+++ b/src/koopmans/workflows/_ml.py
@@ -1,8 +1,6 @@
 """Machine learning workflows for koopmans."""
 from typing import Any, Dict, List
 
-from pydantic import ConfigDict
-
 from koopmans import calculators
 from koopmans.files import File
 from koopmans.process_io import IOModel
@@ -35,7 +33,6 @@ class PowerSpectrumDecompositionOutput(IOModel):
     """Output model for the PowerSpectrumDecompositionWorkflow."""
 
     descriptors: List[File]
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class PowerSpectrumDecompositionWorkflow(Workflow[PowerSpectrumDecompositionOutput]):
@@ -142,7 +139,6 @@ class ConvertOrbitalFilesToXMLOutput(IOModel):
 
     total_density: File
     orbital_densities: List[File]
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class ConvertOrbitalFilesToXMLWorkflow(Workflow[ConvertOrbitalFilesToXMLOutput]):

--- a/src/koopmans/workflows/_unfold_and_interp.py
+++ b/src/koopmans/workflows/_unfold_and_interp.py
@@ -11,7 +11,6 @@ from typing import Dict, List, Literal, Optional
 import numpy as np
 from ase_koopmans.dft.dos import DOS
 from ase_koopmans.spectrum.band_structure import BandStructure
-from pydantic import ConfigDict
 
 from koopmans import calculators, utils
 from koopmans.files import File
@@ -30,7 +29,6 @@ class UnfoldAndInterpolateOutput(IOModel):
     band_structure: BandStructure
     dos: Optional[DOS]
     smooth_dft_ham_files: Optional[Dict[BlockID, File]]
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class UnfoldAndInterpolateWorkflow(Workflow):

--- a/src/koopmans/workflows/_wannierize.py
+++ b/src/koopmans/workflows/_wannierize.py
@@ -14,7 +14,6 @@ from typing import Any, Dict, List, Optional, TypeVar
 from ase_koopmans.dft.kpoints import BandPath
 from ase_koopmans.spectrum.band_structure import BandStructure
 from ase_koopmans.spectrum.doscollection import GridDOSCollection
-from pydantic import ConfigDict
 
 # isort: off
 import koopmans.mpl_config  # noqa: F401
@@ -50,7 +49,6 @@ class WannierizeOutput(IOModel):
     preprocessing_calculations: List[calculators.Wannier90Calculator]
     nscf_calculation: calculators.PWCalculator
     wannier90_calculations: List[calculators.Wannier90Calculator]
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class WannierizeWorkflow(Workflow[WannierizeOutput]):
@@ -394,7 +392,6 @@ class WannierizeBlockOutput(IOModel):
     u_matrices_file: File | None = None
     wannier90_calculation: calculators.Wannier90Calculator
     preprocessing_calculation: calculators.Wannier90Calculator
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class WannierizeBlockWorkflow(Workflow[WannierizeBlockOutput]):
@@ -431,8 +428,7 @@ class WannierizeBlockWorkflow(Workflow[WannierizeBlockOutput]):
         calc_w90_pp: calculators.Wannier90Calculator = self.new_calculator(
             calc_type, init_orbitals=init_orbs, **self.block.w90_kwargs)
         calc_w90_pp.prefix = 'wannier90_preproc'
-        calc_w90_pp.command.flags = '-pp'
-        status = self.run_steps(calc_w90_pp)
+        status = self.run_steps(calc_w90_pp, additional_flags=['-pp'])
         if status != Status.COMPLETED:
             return
 

--- a/src/koopmans/workflows/_workflow.py
+++ b/src/koopmans/workflows/_workflow.py
@@ -830,7 +830,7 @@ class Workflow(utils.HasDirectory, ABC, Generic[OutputModel]):
 
         self.atoms = self.atoms[mask]
 
-    def run_steps(self, steps: ProcessProtocol | Sequence[ProcessProtocol]) -> Status:
+    def run_steps(self, steps: ProcessProtocol | Sequence[ProcessProtocol], additional_flags: list[str] = []) -> Status:
         """Run a sequence of steps in the workflow.
 
         Run either a step or sequence (i.e. list) of steps. If a list is provided, the steps must be able to be run
@@ -866,7 +866,7 @@ class Workflow(utils.HasDirectory, ABC, Generic[OutputModel]):
             if status == Status.NOT_STARTED:
                 # Run the step
                 logger.info(f'Submitting {step.directory} ({step.__class__.__name__})')
-                self.engine.run(step)
+                self.engine.run(step, additional_flags=additional_flags)
             else:
                 logger.info(f'Step {step.name} is already {status}')
 

--- a/tests/helpers/patches/_mock.py
+++ b/tests/helpers/patches/_mock.py
@@ -123,11 +123,6 @@ def mock_calculator_is_complete(self):
     return (self.directory / f'{self.prefix}{self.ext_out}').is_file()
 
 
-def mock_calculator_check_code_is_installed(self):
-    """Make sure that a MockCalc does not attempt to check if the code is installed."""
-    pass
-
-
 def mock_calculator_read_results(self) -> None:
     """Make sure that a MockCalc does not attempt to read results."""
     raise AssertionError('A MockCalc should not attempt to read results')
@@ -185,7 +180,6 @@ def monkeypatch_mock(monkeypatch):
               KoopmansHamCalculator, ProjwfcCalculator]:
         monkeypatch.setattr(c, '_calculate', mock_calculator__calculate)
         monkeypatch.setattr(c, 'is_complete', mock_calculator_is_complete)
-        monkeypatch.setattr(c, 'check_code_is_installed', mock_calculator_check_code_is_installed)
         monkeypatch.setattr(c, 'read_results', mock_calculator_read_results)
 
     patch_generate_dos(ProjwfcCalculator, monkeypatch)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,51 +1,88 @@
-"""Test the `koopmans.commands` module."""
+"""Tests for the CommandConfig subclasses."""
 
-import os
-
-import pytest
-
-from koopmans import utils
-from koopmans.commands import (Command, ParallelCommand,
-                               ParallelCommandWithPostfix)
+from koopmans.commands import (CommandConfigs, KCPConfig, KCWHamConfig,
+                               PWConfig, Wannier90Config)
 
 
-def test_command():
-    """Test the Command class creation."""
-    # Creation from a string
-    c_str = 'pw.x -in in.pwi > out.pwi'
-    c = Command(c_str)
-    assert c.executable == 'pw.x'
-    assert str(c) == c_str
+def test_kcw_config():
+    """Test the KCWHamConfig class."""
+    config = KCWHamConfig(mpi_executable="srun", num_tasks=8, stdin="PREFIX.khi", stdout="PREFIX.kho")
 
-    # Creation from another command object
-    c2 = Command(c)
-    assert c2.executable == 'pw.x'
-    assert str(c2) == c_str
+    assert config.executable == "kcw.x"
+    assert config.stdin == "PREFIX.khi"
+    assert config.stdout == "PREFIX.kho"
 
+    assert config.command() == "srun -n 8 kcw.x -in PREFIX.khi > PREFIX.kho 2>&1"
 
-parallel_commands = [('mpirun -n 16', 'pw.x', '-in in.pwi > out.pwi'),
-                     ('srun', 'pw.x', '-in in.pwi > out.pwo 2>&1'),
-                     ('srun --mpi=pmi2 -n 48', 'pw.x', '-in in.pwi > out.pwo 2>&1')]
+    second_config = KCWHamConfig.from_string(config.command())
+    assert second_config == config
 
 
-@pytest.mark.parametrize('mpi_command,executable,suffix', parallel_commands)
-def test_parallel_command(mpi_command, executable, suffix):
-    """Test the ParallelCommand class."""
-    c_str = ' '.join((mpi_command, executable, suffix))
-    c = ParallelCommand(c_str)
+def test_kcp_config():
+    """Test the KCPConfig class."""
+    config = KCPConfig(mpi_executable="mpirun", num_tasks=4)
 
-    assert c.executable == executable
-    assert c.mpi_command == mpi_command
-    assert str(c) == c_str
+    assert config.executable == "kcp.x"
+    assert config.stdin == "PREFIX.cpi"
+    assert config.stdout == "PREFIX.cpo"
+    assert config.command() == "mpirun -n 4 kcp.x -in PREFIX.cpi > PREFIX.cpo 2>&1"
+
+    second_config = KCPConfig.from_string(config.command())
+    assert second_config == config
 
 
-def test_parallel_command_with_postfix():
-    """Test the ParallelCommandWithPostfix class."""
-    with utils.set_env(PARA_POSTFIX='-npool 4'):
-        c_str = 'mpirun -n 16 pw.x -in in.pwi > out.pwi'
-        postfix = '-npool 4'
-        os.environ['PARA_POSTFIX'] = postfix
-        c = ParallelCommandWithPostfix(c_str)
+def test_calculator_configs_ase_command(monkeypatch):
+    """Test the CalculatorConfigs class when ASE_KCW_HAM_COMMAND is set."""
+    custom_command = "mpirun -n 3 kcw.x -in PREFIX.khi > PREFIX.kho 2> PREFIX.err"
+    monkeypatch.delenv("PARA_PREFIX", False)
+    monkeypatch.setenv("ASE_KCW_HAM_COMMAND", custom_command)
 
-        assert c.postfix == postfix
-        assert c.flags == postfix
+    config = CommandConfigs()
+    assert config.kcw_ham.command() == custom_command
+
+
+def test_calculator_configs_para_prefix(monkeypatch):
+    """Test the CalculatorConfigs class when PARA_PREFIX is set."""
+    # Make sure we don't have any environment variables
+    monkeypatch.delenv("ASE_KCW_HAM_COMMAND", False)
+    monkeypatch.delenv("ASE_PW_COMMAND", False)
+    monkeypatch.delenv("PARA_PREFIX", False)
+
+    # Check by default that mpirun is used
+    config = CommandConfigs()
+    assert config.kcw_ham.mpi_executable == "mpirun"
+
+    # Check that when PARA_PREFIX is set it propagates to all subclasses
+    monkeypatch.setenv("PARA_PREFIX", "srun")
+    config = CommandConfigs()
+    assert config.kcw_ham.mpi_executable == "srun"
+    assert config.kcw_ham.num_tasks is None
+
+    # Check that explicitly providing `mpi_executable` to a calculator takes precedence over PARA_PREFIX
+    config = CommandConfigs(pw={"mpi_executable": "mpirun"})
+    assert config.kcw_ham.mpi_executable == "srun"
+    assert config.pw.mpi_executable == "mpirun"
+
+    # Check that explicitly providing `mpi_executable` to the entire config class takes precedence over PARA_PREFIX
+    config = CommandConfigs(mpi_executable="srun")
+    assert config.kcw_ham.mpi_executable == "srun"
+    assert config.pw.mpi_executable == "srun"
+
+
+def test_pw_config_from_string():
+    """Test PWConfig.from_string()."""
+    command = "mpirun -n 4 pw.x -npool 4 -pd .true. -in PREFIX.pwi > PREFIX.pwo 2>&1"
+    config = PWConfig.from_string(command)
+    assert config.pd
+    assert config.npool == 4
+
+
+def test_wannier90_preproc_from_string():
+    """Test Wannier90PreprocConfig.from_string()."""
+    command = "wannier90.x -pp PREFIX.w90"
+    config = Wannier90Config.from_string(command)
+    assert config.command() == command
+    assert config.executable == "wannier90.x"
+    assert config.stdin == "PREFIX.w90"
+    assert config.pp
+    assert config.command() == command

--- a/tutorials/tutorial_3/01-ki/zno.json
+++ b/tutorials/tutorial_3/01-ki/zno.json
@@ -13,8 +13,13 @@
     },
     "engine": {
         "from_scratch": true,
-        "npool": 4
+        "commands": {
+            "pw": {
+                "npool": 4
+            }
+        }
     },
+
     "atoms": {
        "cell_parameters": {
          "periodic": true,

--- a/tutorials/tutorial_3/02-dft_bands/zno.json
+++ b/tutorials/tutorial_3/02-dft_bands/zno.json
@@ -13,8 +13,13 @@
     },
     "engine": {
         "from_scratch": true,
+        "commands": {
+            "pw": {
         "npool": 4
+            }
+        }
     },
+
     "atoms": {
        "cell_parameters": {
          "periodic": true,

--- a/tutorials/tutorial_3/03-wannierize/zno.json
+++ b/tutorials/tutorial_3/03-wannierize/zno.json
@@ -13,8 +13,13 @@
     },
     "engine": {
         "from_scratch": true,
+        "commands": {
+            "pw": {
         "npool": 4
+            }
+        }
     },
+
     "atoms": {
        "cell_parameters": {
          "periodic": true,


### PR DESCRIPTION
This PR overhauls the `koopmans.commands` module in order to make the commands more customizable.

Now, the user can specify code options in the input file as follows:

```
    "engine": {
        "from_scratch": true,
        "commands": {
            "pw": {
                "npool": 4
            },
            "pw2wannier": {
                "pd": True
            }
        }
    },
```

Internally, this PR also standardizes the use of `ASE_<CODE_NAME>_COMMAND` environment variables (which previously were defined in different places for one calculator to the next.)